### PR TITLE
fix: footer timezone bug

### DIFF
--- a/scripts/nodes/footer.mjs
+++ b/scripts/nodes/footer.mjs
@@ -3,7 +3,10 @@ import formatter from '@uiw/formatter';
 export function footer(options = {}) {
   let footerText = '© 2022 Kenny Wang.';
   if (options.isHome) {
-    footerText += ` Updated on ${formatter('YYYY/MM/DD HH:mm:ss', new Date())}`;
+    const now = new Date();
+    const utc = now.getTime() + now.getTimezoneOffset() * 60000;
+    const cst = new Date(utc + 3600000 * 8);
+    footerText += ` Updated on ${formatter('YYYY/MM/DD HH:mm:ss', cst)}`;
   }
   return {
     type: 'element',


### PR DESCRIPTION
用 Github Action build 的页脚时间是UTC时区，容易造成误解
先把时间都转UTC，再转CST 中国标准时间

情况一、在国内 build，`now.getTimezoneOffset()` 为 -480，
情况二、在 Github Action build, `now.getTimezoneOffset()` 为 0

都可以得到正确的时间

copilot 真好用 :smile: