### PR TITLE
bug: the dependencies of pnpm

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+shamefully-hoist = true


### PR DESCRIPTION
pnpm 对于 refs-cli 中的部分依赖无法提升到根模块，需要使用 shamefully-hoist 