### PR TITLE
Update java.md

### DIFF
--- a/docs/java.md
+++ b/docs/java.md
@@ -842,4 +842,4 @@ method.invoke(classLoader, url);
 另见
 ---
 
-- [Java 官网](https://www.java.com/zh-CN/) _(java.com)_
+- [Java 官网](https://www.oracle.com/cn/java/) _(https://www.oracle.com/cn/java/)_


### PR DESCRIPTION
原来的 Java 官网弃用了，https://www.oracle.com/cn/java/ 是现在的 Java 官网