### PR TITLE
将PHP、Python、YAML的“Learn X in Y minutes”链接替换成中文版本

### DIFF
--- a/docs/php.md
+++ b/docs/php.md
@@ -969,4 +969,4 @@ echo 'CURRENT_DATE is: ' . CURRENT_DATE;
 ----
 
 - [PHP 官方中文文档](https://www.php.net/manual/zh/index.php) _(php.net)_
-- [Learn X in Y minutes](https://learnxinyminutes.com/docs/php/) _(learnxinyminutes.com)_
+- [Learn X in Y minutes](https://learnxinyminutes.com/docs/zh-cn/php-cn/) _(learnxinyminutes.com)_

--- a/docs/python.md
+++ b/docs/python.md
@@ -1249,5 +1249,5 @@ finally:                 # 在所有情况下执行
 ----
 
 - [Python](https://www.python.org/)  _(python.org)_
-- [Learn X in Y minutes](https://learnxinyminutes.com/docs/python/) _(learnxinyminutes.com)_
+- [Learn X in Y minutes](https://learnxinyminutes.com/docs/zh-cn/python-cn/) _(learnxinyminutes.com)_
 - [Regex in python](./regex.md#python-中的正则表达式) _(jaywcjlove.github.io)_

--- a/docs/yaml.md
+++ b/docs/yaml.md
@@ -520,7 +520,7 @@ YAML 参考
 ---
 
 - [YAML Reference Card](https://yaml.org/refcard.html) _(yaml.org)_
-- [Learn X in Y minutes](https://learnxinyminutes.com/docs/yaml/) _(learnxinyminutes.com)_
+- [Learn X in Y minutes](https://learnxinyminutes.com/docs/zh-cn/yaml-cn/) _(learnxinyminutes.com)_
 - [YAML lint online](http://www.yamllint.com/) _(yamllint.com)_
 - [INI 格式配置文件备忘清单](./ini.md) _(jaywcjlove.github.io)_
 - [TOML 格式配置文件备忘清单](./toml.md) _(jaywcjlove.github.io)_


### PR DESCRIPTION
目前PHP、Python、YAML、TOML的“另见”部分有“Learn X in Y minutes”的链接，除了TOML外的三者都有对应的中文版本。