### PR TITLE
fix: markdown.md格式排版问题修复

### DIFF
--- a/docs/markdown.md
+++ b/docs/markdown.md
@@ -131,13 +131,11 @@ ___
 
 ### 代码
 
-```markdown
-
+````markdown
 ```javascript
 console.log("This is a block code")
 ```
-
-```
+````
 
 ```markdown
 ~~~css


### PR DESCRIPTION
修复`Markdown 备忘清单`中代码章节出现的问题。
![image](https://github.com/jaywcjlove/reference/assets/74407127/9eba0eea-1dc5-402a-af6d-e602eea8a082)
