### PR TITLE
[python.md] Add Steps for adding pipenv to system path

### DIFF
--- a/docs/python.md
+++ b/docs/python.md
@@ -1851,6 +1851,12 @@ brew upgrade pipenv                 # homebrew
 ```
 
 ```shell
+# 将 pipenv 命令加入到系统环境变量 $PATH 中 (Unix and MacOS)
+dir=$(python -c 'import site; print(site.USER_BASE + "/bin")') # 打印 python site-packages bin 路径
+echo 'export PATH="'$dir':$PATH"' >> ~/.zshrc # 将 dir 路径加入到 PATH 中
+source ~/.zshrc
+
+
 # 安装 package
 pipenv install <package name> # 不指定版本
 pipenv install <package name>==<version>    # 精确指定版本


### PR DESCRIPTION
when we installed pipenv pkg, we can't run pipenv install command on our local shell, because maybe we didn't have the site-package-bin dir in system $PATH, so we need to add it firstly.