### PR TITLE
doc: Update cpp.md

### DIFF
--- a/docs/cpp.md
+++ b/docs/cpp.md
@@ -30,7 +30,7 @@ Hello Quick Reference
 int number = 5;       // 整数
 float f = 0.95;       // 浮点数
 double PI = 3.14159;  // 浮点数
-char yes = 'Y';       // 特点
+char yes = 'Y';       // 字符
 std::string s = "ME"; // 字符串（文本）
 bool isRight = true;  // 布尔值
 // 常量
@@ -327,14 +327,14 @@ else
 
 #### 位运算符
 
-| Operator | Description             |
-|----------|-------------------------|
-| `a & b`  | Binary AND              |
-| `a | b`  | Binary OR               |
-| `a ^ b`  | Binary XOR              |
-| `a ~ b`  | Binary One's Complement |
-| `a << b` | Binary Shift Left       |
-| `a >> b` | Binary Shift Right      |
+| 运算符 | 描述 |
+|--------|------|
+| `a & b`  | 按位与 |
+| <code>a &#124; b</code>  | 按位或 |
+| `a ^ b`  | 按位异或 |
+| `~a`     | 按位取反 |
+| `a << b` | 左移 |
+| `a >> b` | 右移 |
 
 ### 三元运算符
 
@@ -621,7 +621,7 @@ auto func = []() -> return_type { };
                     ? val1 : val2;
           };
 
-      auto func2 = [&, val1]() -> int
+      auto func2 = [&, val1]() -> string
           {
               return   str1 == std::to_string(val1)
                     ? str1 : str2;
@@ -926,7 +926,7 @@ int val = result.get();
 extern double foo(int val) {}
 
 std::future<double> result =
-    async(foo, 5);
+    std::async(foo, 5);
 
 //返回值类型
 std::future_status status;


### PR DESCRIPTION
修正了 C++ 备忘清单中 Lambda 
表达式部分的类型不匹配问题：

- 将混合隐式捕获示例中 func2 的返回类型从 int 改为 string，使其与函数体中实际返回的字符串类型匹配
- 这样可以避免编译错误并提供更准确的示例代码

此外，还修正了以下问题：
- 位运算符部分使用了 HTML 实体来正确显示按位或运算符 (|)
- 变量描述部分将 `char yes = 'Y';` 的注释从"特点"修正为"字符"

这些修改使得 C++ 备忘清单更加准确和可靠，对学习 C++ 的开发者更有帮助。


修改前：
![image](https://github.com/user-attachments/assets/b9881c41-e19f-4f3e-98cb-76b49f0f1129)
修改后：
![image](https://github.com/user-attachments/assets/70b1fd1e-45e3-42ec-b0d4-ebc744b35034)
![image](https://github.com/user-attachments/assets/b7d993f9-2397-443d-913a-02470dad1e0c)
![image](https://github.com/user-attachments/assets/5c471608-9dc1-4f77-abf5-6793b822c307)