### PR TITLE
add web site: note-bin.top:10443 with ipv6

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,6 +623,7 @@ Quick Reference
 [leonus.cn](https://ref.leonus.cn/)<!--rehype:target=_blank-->
 [taotaome.com](http://www.taotaome.com/)<!--rehype:target=_blank-->
 [hurcaguari.top](https://help.hurcaguari.top)<!--rehype:target=_blank-->
+[notes-bin.top](https://notes-bin.top:10443)<!--rehype:target=_blank&class=contributing&data-info=仅IPv6 👆每天自动同步-->
 <!--rehype:class=home-card home-links-->
 
 下面网站暂时飞走了
@@ -645,7 +646,6 @@ Quick Reference
 [longdada.me](https://ref.longdada.me)<!--rehype:target=_blank-->
 [chenze.cloud](https://quick.chenze.cloud)<!--rehype:target=_blank-->
 [lzzzt.cn](https://ref.lzzzt.cn)<!--rehype:target=_blank-->
-[notes-bin.top](https://notes-bin.top)<!--rehype:target=_blank-->
 [fifo.site](https://ref.fifo.site)<!--rehype:target=_blank-->
 [longdada.me](https://ref.longdada.me)<!--rehype:target=_blank-->
 [btaw.cn](https://btaw.cn/qr)<!--rehype:target=_blank-->


### PR DESCRIPTION
note-bin.top已迁移到新服务器上, 仅使用ipv6, 因isp限制不能使用443端口, 使用10443端口,每晚0点自动更新.
完整URL: [note-bin.top](https://notes-bin.top:10443), 未及时通知,请见谅.