### PR TITLE
完善 Chown 与 CMake 备忘清单

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,6 @@ Quick Reference
 [MATLAB](./docs/matlab.md)<!--rehype:style=background:rgb(0 118 168);&class=contributing-->
 [Pytorch](./docs/pytorch.md)<!--rehype:style=background:rgb(238 76 44);&class=contributing tag&data-lang=Python&data-info=👆看看还缺点儿什么？-->
 [Vue 3](./docs/vue.md)<!--rehype:style=background:rgb(64 184 131);&class=contributing-->
-[Chown](./docs/chown.md)<!--rehype:style=background:rgb(12 75 51/var(\-\-bg\-opacity));&class=contributing-->
 [R 语言](./docs/r.md)<!--rehype:style=background:rgb(39 108 192);&class=contributing-->
 [Elixir](./docs/elixir.md)<!--rehype:style=background:rgb(124 26 156);&class=contributing tag&data-lang=Elixir-->
 [Tauri](./docs/tauri.md)<!--rehype:style=background:rgb(103 214 237);&class=contributing-->
@@ -274,7 +273,7 @@ Quick Reference
 [Awk](./docs/awk.md)<!--rehype:style=background:rgb(16 185 129);-->
 [Curl](./docs/curl.md)<!--rehype:style=background:rgb(16 185 129);-->
 [Chmod](./docs/chmod.md)<!--rehype:style=background:rgb(16 185 129);-->
-[Chown](./docs/chown.md)<!--rehype:style=background:rgb(12 75 51/var(\-\-bg\-opacity));&class=contributing-->
+[Chown](./docs/chown.md)<!--rehype:style=background:rgb(12 75 51/var(\-\-bg\-opacity));-->
 [Cron](./docs/cron.md)<!--rehype:style=background:rgb(239 68 68);-->
 [CMake](./docs/cmake.md)<!--rehype:style=background:rgb(92 107 192);&class=contributing-->
 [CMD](./docs/cmd.md)<!--rehype:style=background:rgb(99 99 99);-->

--- a/README.md
+++ b/README.md
@@ -114,7 +114,6 @@ Quick Reference
 <!--rehype:style=padding-bottom: 23px;-->
 
 [Ansible](./docs/ansible.md)<!--rehype:style=background:rgb(238 0 0);&class=contributing tag&data-lang=RedHat&data-info=👆看看还缺点儿什么？-->
-[CMake](./docs/cmake.md)<!--rehype:style=background:rgb(92 107 192);&class=contributing-->
 [C#](./docs/cs.md)<!--rehype:style=background:rgb(6 147 13);&class=contributing-->
 [Django](./docs/django.md)<!--rehype:style=background:rgb(12 75 51);&class=contributing tag&data-lang=Python-->
 [Flask](./docs/flask.md)<!--rehype:style=background:rgb(210 168 255);&class=contributing tag&data-lang=Python-->
@@ -275,7 +274,7 @@ Quick Reference
 [Chmod](./docs/chmod.md)<!--rehype:style=background:rgb(16 185 129);-->
 [Chown](./docs/chown.md)<!--rehype:style=background:rgb(12 75 51/var(\-\-bg\-opacity));-->
 [Cron](./docs/cron.md)<!--rehype:style=background:rgb(239 68 68);-->
-[CMake](./docs/cmake.md)<!--rehype:style=background:rgb(92 107 192);&class=contributing-->
+[CMake](./docs/cmake.md)<!--rehype:style=background:rgb(92 107 192);-->
 [CMD](./docs/cmd.md)<!--rehype:style=background:rgb(99 99 99);-->
 [.NET CLI](./docs/dotnet-cli.md)<!--rehype:style=background:rgb(16 185 129);&class=contributing tag&data-lang=#C-->
 [Find](./docs/find.md)<!--rehype:style=background:rgb(16 185 129);-->

--- a/docs/chown.md
+++ b/docs/chown.md
@@ -1,149 +1,226 @@
 Chown 备忘清单
 ===
 
-这份快速参考备忘单提供了改变文件或目录的所有者的简要概述，以及 chown 命令的操作
+这份快速参考备忘单整理了 `chown` 修改文件所有者和属组的常用语法、选项、递归行为与安全示例
 
 入门
 --------
 
-### 介绍
-
-Linux/Unix 系统中的一个命令，全称为 `change owner`，用于改变文件或目录的所有者
+### 语法
 
 ```shell
-chown [选项] [所有者][:[组]] 文件或目录名
+$ chown [选项]... [所有者][:[属组]] 文件...
+$ chown [选项]... --reference=参考文件 文件...
 ```
 
-命令可以更改某个文件或目录的属主（owner），也可以同时更改其属组（group）
+`chown` 用于修改文件或目录的所有者，也可以同时修改属组。修改文件所有者通常需要管理员权限。
 
 #### 示例
 
 ```shell
-$ chown :groupname file1.txt
-$ chown -R username:groupname *
-$ chown $USER file.txt
+$ sudo chown alice report.txt
+$ sudo chown alice:staff report.txt
+$ sudo chown -R alice:staff project/
+$ sudo chown --reference=template.txt target.txt
 ```
 
-`注意` 只有超级用户(root)才有权限改变文件或目录的所有者
+### 所有者与属组
+<!--rehype:wrap-class=col-span-2-->
 
-### 选项
+写法 | 含义
+:- | :-
+`alice` | 只把所有者改为 `alice`，属组保持不变
+`alice:staff` | 所有者改为 `alice`，属组改为 `staff`
+`alice:` | 所有者改为 `alice`，属组改为 `alice` 的登录属组
+`:staff` | 只把属组改为 `staff`，效果类似 `chgrp staff`
+`:` | 不改变所有者或属组
+`+1001:+1001` | 使用数字 UID/GID，`+` 可避免与同名用户或组混淆
+<!--rehype:className=show-header-->
 
-- `-c` : 显示更改的部分的信息
-- `-f` : 忽略错误信息
-- `-h` :修复符号链接
-- `-v` : 显示详细的处理信息
-- `-R` : 处理指定目录以及其子目录下的所有文件
-- `--help` : 显示辅助说明
-- `--version` : 显示版本
+### 常用选项
 
-示例
+选项 | 说明
+:- | :-
+`-c`, `--changes` | 只在发生变更时输出信息
+`-f`, `--silent`, `--quiet` | 抑制大多数错误信息
+`-v`, `--verbose` | 为每个处理的文件输出诊断信息
+`-R`, `--recursive` | 递归处理目录及其内容
+`--from=当前所有者:当前属组` | 仅当当前所有者或属组匹配时才修改
+`--reference=参考文件` | 使用参考文件的所有者和属组
+`--preserve-root` | 递归操作 `/` 时失败，防止误操作根目录
+`--no-preserve-root` | 不对 `/` 做特殊保护
+`--help` | 显示帮助
+`--version` | 显示版本
+<!--rehype:className=show-header-->
+
+### 符号链接
+
+选项 | 说明
+:- | :-
+`--dereference` | 修改符号链接指向的目标，这是默认行为
+`-h`, `--no-dereference` | 修改符号链接本身，而不是它指向的目标
+`-H` | 与 `-R` 一起使用；命令行参数中的目录符号链接会被遍历
+`-L` | 与 `-R` 一起使用；遍历遇到的每个目录符号链接
+`-P` | 与 `-R` 一起使用；不遍历任何符号链接，GNU 默认值
+<!--rehype:className=show-header-->
+
+常用示例
 --------
 
-### 更改文件所有者
+### 修改文件所有者
 
 ```shell
-$ chown root /var/run/httpd.pid
+$ sudo chown alice report.txt
 ```
 
-把 `/var/run/httpd.pid` 的所有者设为 `root`
+把 `report.txt` 的所有者改为 `alice`，文件属组保持不变。
 
-#### 仅更改所有者
+### 同时修改所有者和属组
 
-```bash
-$ chown new_owner file.txt
+```shell
+$ sudo chown alice:staff report.txt
 ```
 
-### 递归更改目录及其内容的所有者
+把 `report.txt` 的所有者改为 `alice`，属组改为 `staff`。
+
+### 只修改属组
+
+```shell
+$ sudo chown :staff report.txt
+```
+
+不改变文件所有者，只把属组改为 `staff`。
+
+### 使用登录属组
+
+```shell
+$ sudo chown alice: report.txt
+```
+
+所有者改为 `alice`，属组改为 `alice` 的登录属组。
+
+### 递归修改目录
 <!--rehype:wrap-class=row-span-2-->
 
 ```shell
-chown -R new_owner:new_group directory/
+$ sudo chown -R alice:staff project/
 ```
 
-将文件夹 `directory` 的拥有者设为 `new_owner` ，群体的使用者设为 `new_group`
+递归修改 `project/` 目录及其所有内容的所有者和属组。
 
 ```shell
-$ chown username:groupname file1.txt
+$ sudo chown --preserve-root -R alice:staff /srv/app
 ```
 
-将文件 file1.txt 的拥有者设为 `username` ，群体的使用者设为 `groupname`
+递归处理重要路径时可加 `--preserve-root`，降低误把根目录作为目标的风险。
 
-```shell
-$ chown -R username:groupname *
-```
-
-将当前目录以及子目录的所有文件的拥有者设为 `username` ，群体的使用者设为 `groupname`
-
-### 更改所有者为当前用户
-
-```bash
-$ chown $USER file.txt
-```
-
-递归更改目录及其内容的所有者为当前用户
-
-```bash
-sudo chown -R $USER directory/
-```
-
-### 递归并且不显示错误信息
-
-```bash
-chown -R -f new_owner:new_group directory/
-```
-
-更改目录及其内容的所有者和组为 `alice`
-
-```bash
-chown -R alice: directory/
-```
-
-### 仅更改组
-
-```shell
-$ chown :groupname file1.txt
-```
-
-不修改文件 `file1.txt` 的拥有者，将文件使用群体改为 `groupname`
-
-### 变更符号链接的所有者
+### 按当前归属条件修改
 <!--rehype:wrap-class=row-span-2-->
 
-```bash
-$ chown -h new_owner:new_group symlink
+```shell
+$ sudo chown --from=root:root app:app config.yml
 ```
 
-变更符号链接的所有者而不是链接指向的文件
+只有当 `config.yml` 当前所有者和属组都是 `root` 时，才改为 `app:app`。
 
-```bash
-$ chown -h manager symlink
+```shell
+$ sudo chown --from=:oldgroup :newgroup *.log
 ```
 
-更改符号链接的所有者为"manager"
+只要求当前属组匹配 `oldgroup`，匹配后把属组改为 `newgroup`。
 
-### 更改所有者为根用户
-<!--rehype:wrap-class=row-span-2-->
+### 参照其他文件
 
-```bash
-sudo chown root:root file.txt
+```shell
+$ sudo chown --reference=template.txt target.txt
 ```
 
-#### 递归更改所有者为当前用户
+把 `target.txt` 的所有者和属组改成与 `template.txt` 相同。
 
-```bash
-sudo chown -R $USER directory/
-# 更改目录及其内容的所有者和组为"alice":
-chown -R alice: directory/
+### 修改符号链接本身
+
+```shell
+$ sudo chown -h alice:staff current-link
 ```
 
-### 将文件所有者更改为其他用户，但保留组
+修改符号链接 `current-link` 自身的所有者和属组，而不是它指向的目标文件。
 
-```bash
-chown new_owner file.txt
+### 递归时不遍历符号链接
+
+```shell
+$ sudo chown -R -P app:app /srv/app
 ```
 
-### 将文件所有者更改为其他用户，同时更改组
+`-P` 会让递归过程不进入符号链接指向的目录，适合多数需要避免越界修改的场景。
 
-```bash
-chown new_owner:new_group file.txt
+实践
+--------
+
+### Web 应用目录
+
+```shell
+$ sudo chown -R app:app /srv/app
+$ sudo chown -R www-data:www-data /var/www/example
 ```
+
+把应用目录交给运行服务的用户和属组，避免用 `root` 直接运行应用进程。
+
+### 上传目录
+
+```shell
+$ sudo chown -R www-data:www-data /var/www/example/uploads
+```
+
+只给需要写入的目录设置 Web 服务用户归属，其他代码目录应尽量保持只读权限。
+
+### 恢复当前用户归属
+
+```shell
+$ sudo chown -R "$USER":"$USER" ~/.config/my-tool
+```
+
+当配置目录被 `sudo` 创建后，可把它恢复为当前用户拥有。
+
+### 避免通配符误伤
+
+```shell
+$ sudo chown -R app:app /srv/app/
+$ sudo chown -R app:app ./
+```
+
+递归操作前优先使用明确路径。避免在不确定的工作目录中直接执行 `chown -R user:group *`。
+
+排错
+--------
+
+### 查看当前归属
+
+```shell
+$ ls -l report.txt
+$ stat report.txt
+```
+
+`ls -l` 适合快速查看，`stat` 会显示更完整的 UID、GID 与文件元数据。
+
+### 找出归属不正确的文件
+
+```shell
+$ find /srv/app -not -user app -ls
+$ find /srv/app -not -group app -ls
+```
+
+用 `find` 先列出目标，再决定是否批量修复，能减少递归修改的风险。
+
+### 批量修复特定归属
+
+```shell
+$ sudo find /srv/app -user root -exec chown app:app {} +
+```
+
+只修复当前所有者为 `root` 的文件，避免无差别覆盖整个目录树。
+
+另见
+----
+
+- [GNU Coreutils: chown invocation](https://www.gnu.org/s/coreutils/manual/html_node/chown-invocation.html)
+- [GNU Coreutils: File permissions](https://www.gnu.org/software/coreutils/manual/html_node/File-permissions.html)

--- a/docs/cmake.md
+++ b/docs/cmake.md
@@ -1,162 +1,514 @@
 CMake 备忘清单
 ===
 
-本清单提供了对 CMake 的入门简要概述，以及 CMake 常用示例
+这份快速参考备忘单整理了 CMake 项目配置、生成、构建、测试、安装、目标管理与 Presets 的常用命令和写法
 
 入门
 ---
 
-### Hello CMake
+### CMake 是什么
 
-CMake 是一个用于配置跨平台源代码项目应该如何配置的工具建立在给定的平台上。
+CMake 用来描述项目如何配置和生成构建系统。它不会直接替代编译器，而是为 Ninja、Makefile、Visual Studio、Xcode 等生成对应的构建文件。
 
-```bash
-├── CMakeLists.txt  # 希望运行的 CMake命令
-├── main.cpp        # 带有main 的源文件
-├── include         # 头文件目录
-│   └── header.h
-└── src             # 源代码目录
-    ├── a.c
-    └── b.c
+```text
+.
+├── CMakeLists.txt
+├── include/
+│   └── hello.hpp
+└── src/
+    ├── hello.cpp
+    └── main.cpp
 ```
 
-在此项目上运行 `CMake` 时，系统会要求您提供二进制目录，运行 `CMake` 不会创建最终的可执行文件，而是会为 `Visual Studio`、`XCode` 或 `makefile` 生成项目文件。 使用这些工具构建该项目
+推荐把源码目录和构建目录分离，避免把生成文件写进源码树。
 
-#### CMakeLists.txt
+### 最小项目
+<!--rehype:wrap-class=row-span-2-->
 
 ```cmake
-# 设置可以使用的最低 CMake 版本
-cmake_minimum_required(VERSION 3.5)
-# 设置项目名称
-project (hello_cmake)
-# 添加可执行文件
-add_executable(hello_cmake main.cpp)
-# 添加头文件目录
-target_include_directories(hello_cmake PRIVATE ./include)
-# 批量添加源文件
-file(GLOB SRCS CONFIGURE_DEPENDS ./src/*.cpp)
-target_sources(hello_cmake PUBLIC ${SRCS})
-# 添加第三方库
-find_package(OpenGL CONFIG REQUIRED)
-# 链接第三方库
-target_link_libraries(hello_cmake PRIVATE OpenGL)
-# 指定输出路径
-set_property(TARGET hello_cmake ${CMAKE_SOURCE_DIR}/bin)
+cmake_minimum_required(VERSION 3.20)
 
+project(hello_cmake
+  VERSION 1.0
+  LANGUAGES CXX
+)
+
+add_executable(hello_cmake)
+
+target_sources(hello_cmake
+  PRIVATE
+    src/main.cpp
+    src/hello.cpp
+)
+
+target_include_directories(hello_cmake
+  PRIVATE
+    include
+)
+
+target_compile_features(hello_cmake
+  PRIVATE
+    cxx_std_17
+)
+
+set_target_properties(hello_cmake PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
 ```
 
-#### main.cpp
+优先使用 `target_*` 命令给目标设置属性，让包含目录、编译特性和链接依赖跟随目标传播。
 
-```c
-#include <iostream>
+### 配置与构建
 
-int main(int argc, char *argv[])
+```shell
+$ cmake -S . -B build
+$ cmake --build build
+$ ./build/bin/hello_cmake
+```
+
+`-S` 指定源码目录，`-B` 指定构建目录。后续构建直接使用 `cmake --build build`。
+
+### 指定生成器
+
+```shell
+$ cmake -S . -B build -G Ninja
+$ cmake -S . -B build -G "Unix Makefiles"
+$ cmake -S . -B build -G "Visual Studio 17 2022"
+```
+
+生成器决定 CMake 输出哪一种构建系统。Windows 上 Visual Studio 生成器通常是多配置生成器。
+
+命令行
+---
+
+### 常用命令
+<!--rehype:wrap-class=col-span-2-->
+
+命令 | 说明
+:- | :-
+`cmake -S . -B build` | 配置项目并生成构建系统
+`cmake --build build` | 构建项目
+`cmake --build build --target app` | 构建指定目标
+`cmake --build build --parallel` | 并行构建
+`cmake --install build` | 安装项目
+`ctest --test-dir build` | 运行测试
+`cmake -P script.cmake` | 执行 CMake 脚本
+`cmake -E <command>` | 运行跨平台辅助命令
+`cmake --open build` | 用关联 IDE 打开生成的项目
+`cmake --help` | 查看帮助
+<!--rehype:className=show-header-->
+
+### 配置变量
+
+```shell
+$ cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+$ cmake -S . -B build -DCMAKE_INSTALL_PREFIX=/opt/myapp
+$ cmake -S . -B build -DBUILD_TESTING=ON
+```
+
+`-D名称=值` 会写入 CMake cache。重新配置同一构建目录时，cache 中的值会被复用。
+
+### 单配置与多配置
+<!--rehype:wrap-class=row-span-2-->
+
+```shell
+$ cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
+$ cmake --build build
+```
+
+Ninja、Unix Makefiles 等单配置生成器通常用 `CMAKE_BUILD_TYPE` 选择 `Debug`、`Release`、`RelWithDebInfo` 或 `MinSizeRel`。
+
+```shell
+$ cmake -S . -B build -G "Visual Studio 17 2022"
+$ cmake --build build --config Release
+$ ctest --test-dir build -C Release
+```
+
+Visual Studio、Xcode、Ninja Multi-Config 等多配置生成器通常在构建或测试阶段用 `--config` / `-C` 选择配置。
+
+### 工具链与编译器
+
+```shell
+$ cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=/path/to/toolchain.cmake
+$ cmake -S . -B build -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+```
+
+工具链文件和编译器通常应在第一次配置构建目录时指定。已配置过的构建目录更换工具链时，建议新建构建目录。
+
+### 安装
+
+```shell
+$ cmake --install build
+$ cmake --install build --prefix /tmp/package
+$ cmake --install build --config Release
+```
+
+`--prefix` 可在安装阶段临时覆盖 `CMAKE_INSTALL_PREFIX`。
+
+CMakeLists
+---
+
+### 项目声明
+
+```cmake
+cmake_minimum_required(VERSION 3.20)
+project(myapp VERSION 1.2.0 LANGUAGES C CXX)
+```
+
+`cmake_minimum_required()` 应放在顶层 `CMakeLists.txt` 靠前位置，用来声明所需最低 CMake 版本并设置策略。
+
+### 可执行文件
+
+```cmake
+add_executable(app)
+
+target_sources(app
+  PRIVATE
+    src/main.cpp
+)
+```
+
+可先创建目标，再用 `target_sources()` 追加源文件，便于大型项目分块维护。
+
+### 静态库与共享库
+
+```cmake
+add_library(core STATIC)
+target_sources(core PRIVATE src/core.cpp)
+
+add_library(plugin SHARED)
+target_sources(plugin PRIVATE src/plugin.cpp)
+```
+
+`STATIC` 生成静态库，`SHARED` 生成动态库。不指定类型时由 `BUILD_SHARED_LIBS` 影响默认行为。
+
+### 链接目标
+
+```cmake
+add_executable(app src/main.cpp)
+add_library(core src/core.cpp)
+
+target_link_libraries(app
+  PRIVATE
+    core
+)
+```
+
+链接 CMake 目标时，目标的公开包含目录、编译定义等用法需求会按 `PUBLIC` / `INTERFACE` 传播。
+
+### 作用域
+<!--rehype:wrap-class=col-span-2-->
+
+作用域 | 含义
+:- | :-
+`PRIVATE` | 只用于当前目标本身
+`PUBLIC` | 用于当前目标，并传播给依赖它的目标
+`INTERFACE` | 不用于当前目标，只传播给依赖它的目标
+<!--rehype:className=show-header-->
+
+### 包含目录
+
+```cmake
+target_include_directories(core
+  PUBLIC
+    include
+  PRIVATE
+    src
+)
+```
+
+库的公共头文件目录通常使用 `PUBLIC` 或 `INTERFACE`，内部实现目录使用 `PRIVATE`。
+
+### 编译特性
+
+```cmake
+target_compile_features(core PUBLIC cxx_std_20)
+```
+
+相比手动设置 `CMAKE_CXX_STANDARD`，`target_compile_features()` 更适合按目标声明需要的语言特性。
+
+### 编译定义
+
+```cmake
+target_compile_definitions(core
+  PRIVATE CORE_BUILDING
+  PUBLIC CORE_ENABLE_LOGGING
+)
+```
+
+这会为目标添加预处理宏，相当于编译器参数中的 `-DCORE_BUILDING`。
+
+### 编译选项
+
+```cmake
+target_compile_options(core
+  PRIVATE
+    $<$<CXX_COMPILER_ID:GNU,Clang>:-Wall;-Wextra>
+    $<$<CXX_COMPILER_ID:MSVC>:/W4>
+)
+```
+
+生成器表达式可按编译器、平台、配置等条件启用不同选项。
+
+依赖
+---
+
+### 查找包
+
+```cmake
+find_package(OpenGL REQUIRED)
+
+target_link_libraries(app
+  PRIVATE
+    OpenGL::GL
+)
+```
+
+现代 CMake 包通常提供导入目标，例如 `OpenGL::GL`。优先链接导入目标，而不是手动拼 include 路径和库路径。
+
+### 可选依赖
+
+```cmake
+find_package(ZLIB)
+
+if(ZLIB_FOUND)
+  target_link_libraries(app PRIVATE ZLIB::ZLIB)
+  target_compile_definitions(app PRIVATE HAVE_ZLIB)
+endif()
+```
+
+未加 `REQUIRED` 时，找不到包不会立即失败，可以用 `<PackageName>_FOUND` 判断。
+
+### 子目录
+
+```cmake
+add_subdirectory(third_party/fmt)
+target_link_libraries(app PRIVATE fmt::fmt)
+```
+
+`add_subdirectory()` 会把子项目加入当前构建，适合 vendored 依赖或同仓库子模块。
+
+### FetchContent
+<!--rehype:wrap-class=row-span-2-->
+
+```cmake
+include(FetchContent)
+
+FetchContent_Declare(
+  fmt
+  GIT_REPOSITORY https://github.com/fmtlib/fmt.git
+  GIT_TAG 10.2.1
+)
+
+FetchContent_MakeAvailable(fmt)
+
+target_link_libraries(app PRIVATE fmt::fmt)
+```
+
+`FetchContent` 会在配置阶段获取依赖。生产项目建议固定版本标签或提交哈希，避免构建结果随远端变化。
+
+测试与安装
+---
+
+### CTest
+
+```cmake
+include(CTest)
+
+add_executable(core_tests tests/core_tests.cpp)
+target_link_libraries(core_tests PRIVATE core)
+
+add_test(NAME core_tests COMMAND core_tests)
+```
+
+```shell
+$ cmake -S . -B build -DBUILD_TESTING=ON
+$ cmake --build build
+$ ctest --test-dir build --output-on-failure
+```
+
+`include(CTest)` 会定义 `BUILD_TESTING` 选项，常用于统一开关测试目标。
+
+### 安装目标
+
+```cmake
+install(TARGETS app core
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+)
+
+install(DIRECTORY include/
+  DESTINATION include
+)
+```
+
+`RUNTIME` 对应可执行文件，`LIBRARY` 对应共享库，`ARCHIVE` 对应静态库或导入库。
+
+### 生成配置头
+
+```cmake
+configure_file(
+  config.hpp.in
+  generated/config.hpp
+)
+
+target_include_directories(app
+  PRIVATE
+    "${CMAKE_CURRENT_BINARY_DIR}/generated"
+)
+```
+
+`configure_file()` 可把版本号、开关等配置写入生成头文件。
+
+Presets
+---
+
+### CMakePresets.json
+<!--rehype:wrap-class=row-span-2-->
+
+```json
 {
-  std::cout << "Hello CMake!" << std::endl;
-  return 0;
+  "version": 3,
+  "configurePresets": [
+    {
+      "name": "dev",
+      "displayName": "Dev",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/dev",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "BUILD_TESTING": "ON"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "dev",
+      "configurePreset": "dev"
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "dev",
+      "configurePreset": "dev",
+      "output": {
+        "outputOnFailure": true
+      }
+    }
+  ]
 }
 ```
 
-#### 编译示例
+Presets 用来共享常用配置。团队可提交 `CMakePresets.json`，把个人路径和本地偏好放进 `CMakeUserPresets.json`。
 
-```bash
-$ mkdir build   # 创建 build 目录
-$ cd build      # 进入目录
-$ cmake ..      # 目录的上一级目录运行命令
-$ make          # 使用对应的编译工具
-$ ./hello_cmake # 运行生成的 hello_cmake
-Hello CMake!
+### 使用 Presets
+
+```shell
+$ cmake --list-presets
+$ cmake --preset dev
+$ cmake --build --preset dev
+$ ctest --preset dev
 ```
 
-### cmake
-<!--rehype:wrap-class=col-span-2-->
+Presets 可覆盖配置、构建、测试、打包和工作流等常用步骤。
 
-生成项目构建系统
+常见模式
+---
 
-```bash
-$ cmake [<options>] <path-to-source | path-to-existing-build>bash
-$ cmake [<options>] -S <path-to-source> -B <path-to-build>
-```
-
-建立一个项目
-
-```bash
-$ cmake --build <dir> [<options>] [-- <build-tool-options>]
-```
-
-安装项目
-
-```bash
-$ cmake --install <dir> [<options>]
-```
-
-运行指定项目
-
-```bash
-cmake --build <dir> --target <project>
-```
-
-打开一个项目
-
-```bash
-$ cmake --open <dir>
-```
-
-运行脚本
-
-```bash
-$ cmake [-D <var>=<value>]... -P <cmake-script-file>
-```
-
-运行命令行工具
-
-```bash
-$ cmake -E <command> [<options>]
-```
-
-运行查找包工具
-
-```bash
-$ cmake --find-package [<options>]
-```
-
-运行工作流预设
-
-```bash
-$ cmake --workflow [<options>]
-```
-
-查看帮助
-
-```bash
-$ cmake --help[-<topic>]
-```
-
-#### 常用参数
-
-- 方式一: 在`CMakeLists.txt`中使用`set(KEY VAL)`函数
-- 方式二: 在执行`cmake ...` -D<arg> 指定(只需一次,推荐)
+### 选项开关
 
 ```cmake
-# 指定编译参数(Debug/Release/MinSizeRel/RelWithDebInfo)
-$ cmake ... -D CMAKE_BUILD_TYPE=DEBUG
-# 指定编译链工具(windows下vcpkg需要)
-$ cmake ... -D CMAKE_TOOLCHAIN_FILE=<vcpkg_path>/scripts/buildsystems/vcpkg.cmake
-# 指定编译器
-$ cmake ... -D CAMKE_C_COMPILER=...
-$ cmake ... -D CAMKE_CXX_COMPILER=...
-# 指定生成器
-$ cmake .. -G "Unix Makefile"
-$ cmake .. -G "Ninja"
-$ cmake .. -G "Visual Studio 17 2022"
+option(MYAPP_BUILD_TOOLS "Build command line tools" ON)
 
-# 设置Cpp标准
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON) # 在检测到不支持时出错
-set(CMAKE_CXX_EXTENSIONS ON) #一般设为off，否则在msvc上没有特性会出错
+if(MYAPP_BUILD_TOOLS)
+  add_executable(mytool tools/mytool.cpp)
+  target_link_libraries(mytool PRIVATE core)
+endif()
 ```
+
+`option()` 会创建布尔 cache 变量，用户可通过 `-DMYAPP_BUILD_TOOLS=OFF` 覆盖。
+
+### 源文件收集
+
+```cmake
+target_sources(app
+  PRIVATE
+    src/main.cpp
+    src/app.cpp
+    src/app.hpp
+)
+```
+
+显式列出源文件最稳定。`file(GLOB CONFIGURE_DEPENDS ...)` 可减少维护成本，但新增文件触发重新配置的行为依赖生成器支持。
+
+### 平台判断
+
+```cmake
+if(WIN32)
+  target_compile_definitions(app PRIVATE APP_PLATFORM_WINDOWS)
+elseif(APPLE)
+  target_compile_definitions(app PRIVATE APP_PLATFORM_APPLE)
+elseif(UNIX)
+  target_compile_definitions(app PRIVATE APP_PLATFORM_UNIX)
+endif()
+```
+
+平台条件适合处理系统 API、路径和链接库差异。
+
+### 构建类型判断
+
+```cmake
+target_compile_definitions(app
+  PRIVATE
+    $<$<CONFIG:Debug>:APP_DEBUG_BUILD>
+)
+```
+
+用生成器表达式判断配置，比读取 `CMAKE_BUILD_TYPE` 更适合多配置生成器。
+
+排错
+---
+
+### 查看 Cache
+
+```shell
+$ cmake -S . -B build -LAH
+```
+
+`-L` 列出 cache 变量，`-A` 显示高级变量，`-H` 显示帮助说明。
+
+### 清理重新配置
+
+```shell
+$ cmake --fresh -S . -B build
+```
+
+`--fresh` 会删除已有 `CMakeCache.txt` 和 `CMakeFiles/` 后重新配置，适合解决 cache 污染。
+
+### 输出调试信息
+
+```cmake
+message(STATUS "CMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}")
+message(STATUS "CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}")
+```
+
+`message(STATUS ...)` 适合在配置阶段打印变量，定位路径、选项和依赖查找问题。
+
+### 跟踪变量来源
+
+```shell
+$ cmake -S . -B build --trace-expand
+$ cmake -S . -B build --debug-find
+```
+
+`--trace-expand` 用于查看 CMake 脚本执行过程，`--debug-find` 用于排查 `find_package()` 和 `find_*()` 的搜索路径。
 
 另见
 ----
 
-- [CMake Examples](http://ttroy50.github.io/cmake-examples/) _(ttroy50.github.io)_
+- [CMake 官方文档](https://cmake.org/cmake/help/latest/)
+- [cmake(1) 命令行手册](https://cmake.org/cmake/help/latest/manual/cmake.1.html)
+- [CMake Tutorial](https://cmake.org/cmake/help/latest/guide/tutorial/index.html)
+- [cmake-presets(7)](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html)
+- [cmake-toolchains(7)](https://cmake.org/cmake/help/latest/manual/cmake-toolchains.7.html)


### PR DESCRIPTION
## Summary

- 完善 `docs/chown.md`，补充所有者和属组写法、常用选项、符号链接行为、递归安全实践与排错命令。
- 完善 `docs/cmake.md`，补充配置、构建、安装、目标管理、依赖、CTest、Presets 与常见排错流程。
- 更新 `README.md`，将 Chown 和 CMake 从待完善区域移除，并保留命令分类入口。

## References

- GNU Coreutils `chown` invocation and file permissions documentation.
- CMake official documentation, `cmake(1)`, CMake Tutorial, Presets, and Toolchains manuals.

## Validation

- `npx --yes markdownlint-cli docs/chown.md docs/cmake.md`
- `git diff --check`
- `npm.cmd run build`