### PR TITLE
完善 Yazi 备忘清单

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Quick Reference
 [Taskset](./docs/taskset.md)<!--rehype:style=background:rgb(99 99 99);-->
 [tar](./docs/tar.md)<!--rehype:style=background:rgb(215 89 62);&class=tag&data-lang=解压缩-->
 [7zip](./docs/7zip.md)<!--rehype:style=background:rgb(99 99 99);&class=tag&data-lang=解压缩-->
-[Yazi](./docs/yazi.md)<!--rehype:style=background:rgb(255 165 0);&class=tag&data-lang=文件管理器;&class=contributing-->
+[Yazi](./docs/yazi.md)<!--rehype:style=background:rgb(255 165 0);&class=tag&data-lang=文件管理器;-->
 [Zip](./docs/zip.md)<!--rehype:style=background:rgb(99 99 99);&class=tag&data-lang=解压缩-->
 <!--rehype:class=home-card-->
 

--- a/docs/yazi.md
+++ b/docs/yazi.md
@@ -1,372 +1,379 @@
 Yazi 备忘清单
 ===
 
-这份快速参考备忘单提供了Yazi 快速的终端文件管理的简要概述，以及 Yazi的基本操作
+这份快速参考备忘单整理了 Yazi 终端文件管理器的安装、启动、快捷键、配置、插件、主题和常见排错用法
 
 入门
 ----
 
-### 功能特点
+### 介绍
 
-- <code>**跨平台支持**</code>：Yazi 支持 Linux、macOS 和 Windows，提供一致的跨平台体验
-- <code>**轻量高效**</code>：简洁设计，启动和操作快速，资源消耗低
-- <code>**插件扩展**</code>：支持插件安装，灵活扩展功能
-- <code>**文件操作**</code>：支持复制、剪切、粘贴、删除、重命名等操作，且支持批量和多选功能，提升效率
+Yazi 是一个使用 Rust 编写的终端文件管理器，支持异步文件操作、预览、Vim 风格快捷键、插件和主题扩展。
+
+```shell
+$ yazi
+$ yazi ~/Projects
+$ yazi --help
+```
+
+默认使用三栏视图：父目录、当前目录和预览面板。推荐把它与 shell wrapper 搭配使用，这样退出后可以回到 Yazi 中最后所在目录。
+
+### 可选依赖
+
+工具 | 用途
+:- | :-
+`file` | 文件类型检测，必需
+`nerd-fonts` | 推荐，显示图标
+`ffmpeg` | 视频缩略图
+`7-Zip` | 压缩包预览和解压
+`jq` | JSON 预览
+`poppler` | PDF 预览
+`fd` | 文件名搜索
+`ripgrep` | 文件内容搜索
+`fzf` | 快速目录跳转
+`zoxide` | 智能目录跳转
+<!--rehype:className=show-header-->
 
 ### 安装
+<!--rehype:wrap-class=col-span-2-->
 
-| 系统 | 安装方法 |
-| ----- | ----- |
-| 使用 Cargo 安装 | `cargo install yazi` |
-| Arch Linux | `yay -S yazi` |
-| Debian/Ubuntu | 可以使用 `Cargo` 进行安装 |
-| macOS (使用 Homebrew) | `brew install yazi` |
-| Windows (使用 Carg) | `cargo install yazi` |
-| Windows (使用 Scoop) | `scoop install yazi` |
+系统 | 命令
+:- | :-
+Arch Linux | `sudo pacman -S yazi ffmpeg 7zip jq poppler fd ripgrep fzf zoxide resvg imagemagick`
+Homebrew | `brew install yazi ffmpeg-full sevenzip jq poppler fd ripgrep fzf zoxide resvg imagemagick-full font-symbols-only-nerd-font`
+MacPorts | `sudo port install yazi ffmpeg 7zip jq poppler fd ripgrep fzf zoxide ImageMagick`
+Windows Scoop | `scoop install yazi`
+Windows WinGet | `winget install sxyazi.yazi`
+Snap | `sudo snap install yazi --classic`
+Flatpak | `flatpak run io.github.sxyazi.yazi`
+PyPI | `pipx install yazi-bin`
+Cargo | `cargo install --force yazi-build`
+源码构建 | `cargo build --release --locked`
+<!--rehype:className=show-header-->
 
-### 使用方法
+发行版包多数由社区维护，版本可能滞后。需要最新版本时可使用官方 GitHub Releases、nightly 或源码构建。
 
-#### 命令启动 Yazi
+### Windows 注意事项
+<!--rehype:wrap-class=row-span-2-->
 
-```sh
-yazi
+Yazi 依赖 `file(1)` 检测 MIME 类型。Windows 上官方推荐使用 Git for Windows 附带的 `file.exe`。
+
+```powershell
+$env:YAZI_FILE_ONE = "C:\Program Files\Git\usr\bin\file.exe"
 ```
 
-#### 查看 Yazi 的帮助文档
+如果使用 Scoop 安装 Git，路径通常是：
 
-```sh
-yazi --help
+```powershell
+$env:YAZI_FILE_ONE = "$env:USERPROFILE\scoop\apps\git\current\usr\bin\file.exe"
 ```
 
-## 常用的快捷键
+设置后重启终端。官方不推荐通过 Scoop 或 Chocolatey 单独安装 `file`，因为它们可能无法正确处理 Unicode 文件名。
+
+### Shell Wrapper
+<!--rehype:wrap-class=row-span-2-->
+
+直接运行 `yazi` 退出后不会改变当前 shell 的目录。使用 wrapper 后，按 `q` 退出会切换到 Yazi 退出时所在目录，按 `Q` 退出则不切换。
+
+```bash
+function y() {
+  local tmp="$(mktemp -t "yazi-cwd.XXXXXX")"
+  yazi "$@" --cwd-file="$tmp"
+  if cwd="$(cat -- "$tmp")" && [ -n "$cwd" ] && [ "$cwd" != "$PWD" ]; then
+    builtin cd -- "$cwd"
+  fi
+  rm -f -- "$tmp"
+}
+```
+
+把函数放入对应 shell 的配置文件后，使用 `y` 启动。
+
+快捷键
+----
 <!--rehype:body-class=cols-2-->
 
 ### 导航
 
+键位 | 操作
 :- | :-
-:- | :-
-| `h` | 返回上一级目录 |
-| `j` | 向下移动选中项 |
-| `k` | 向上移动选中项 |
-| `l` | 进入选中的目录或打开文件 |
-<!--rehype:className=shortcuts-->
-
-更多导航命令
-
-| 快捷键                         | 操作说明                                                      |
-| --------------------------- | --------------------------------------------------------- |
-| `K`                | 在预览中向上移动 5 个单位                                            |
-| `J`                | 在预览中向下移动 5 个单位                                            |
-| `g` ⇒ `g` | 将光标移动到顶部                                                  |
-| `G`                | 将光标移动到底部                                                  |
-| `z`                | 通过 fzf 进入目录或显示文件（[cd](https://yazi-rs.github.io/docs/configuration/keymap#mgr.cd) 或 [reveal](https://yazi-rs.github.io/docs/configuration/keymap#mgr.reveal)） |
-| `Z`                | 通过 zoxide 进入目录（[cd](https://yazi-rs.github.io/docs/configuration/keymap#mgr.cd)）                            |
+`h`, `←` | 返回父目录
+`j`, `↓` | 光标下移
+`k`, `↑` | 光标上移
+`l`, `→` | 进入目录
+`K` | 预览向上滚动 5 个单位
+`J` | 预览向下滚动 5 个单位
+`g` ⇒ `g` | 跳到顶部
+`G` | 跳到底部
+`z` | 通过 fzf 进入目录或显示文件
+`Z` | 通过 zoxide 进入目录
+`g` ⇒ `Space` | 交互式输入路径跳转
 <!--rehype:className=shortcuts left-align-->
 
-### 选择操作
+### 选择
 
-| 快捷键                          | 操作说明                                      |
-| ------------------------------ | --------------------------------------------- |
-| <kbd>Space</kbd>               | 切换当前悬停的文件/目录的选择状态             |
-| <kbd>v</kbd>                   | 进入可视模式（选择模式）                      |
-| <kbd>V</kbd>                   | 进入可视模式（取消模式）                      |
-| <kbd>Ctrl</kbd> + <kbd>a</kbd> | 选择所有文件                                  |
-| <kbd>Ctrl</kbd> + <kbd>r</kbd> | 反转当前所有文件的选择状态                    |
-| <kbd>Esc</kbd>                 | 取消所有选择                                  |
+键位 | 操作
+:- | :-
+`Space` | 切换当前项选择状态
+`v` | 进入可视选择模式
+`V` | 进入可视取消选择模式
+`Ctrl` + `a` | 全选
+`Ctrl` + `r` | 反选
+`Esc` | 取消选择
 <!--rehype:className=shortcuts left-align-->
-
-用于选择文件和目录的快捷键命令
 
 ### 文件操作
-<!--rehype:wrap-class=row-span-4-->
+<!--rehype:wrap-class=row-span-2-->
 
-| 快捷键                              | 操作说明                                                                      |
-| ----------------------------------- | ----------------------------------------------------------------------------- |
-| <kbd>o</kbd>                        | 打开选中的文件                                                                |
-| <kbd>O</kbd>                        | 以交互方式打开选中的文件                                                     |
-| <kbd>Enter</kbd>                    | 打开选中的文件                                                                |
-| <kbd>Shift</kbd> + <kbd>Enter</kbd> | 以交互方式打开选中的文件（部分终端尚不支持）                                |
-| <kbd>Tab</kbd>                      | 显示文件信息                                                                  |
-| <kbd>y</kbd>                        | 复制选中的文件                                                                |
-| <kbd>x</kbd>                        | 剪切选中的文件                                                                |
-| <kbd>p</kbd>                        | 粘贴已复制/剪切的文件                                                         |
-| <kbd>P</kbd>                        | 粘贴已复制/剪切的文件（如目标存在则覆盖）                                    |
-| <kbd>Y</kbd> 或 <kbd>X</kbd>        | 取消已复制/剪切状态                                                           |
-| <kbd>d</kbd>                        | 将选中的文件移至回收站                                                        |
-| <kbd>D</kbd>                        | 彻底删除选中的文件                                                            |
-| <kbd>a</kbd>                        | 新建文件（以 / 结尾表示新建目录）                                             |
-| <kbd>r</kbd>                        | 重命名选中的文件                                                              |
-| <kbd>.</kbd>                        | 切换隐藏文件的显示状态                                                       |
+键位 | 操作
+:- | :-
+`o`, `Enter` | 打开选中文件
+`O`, `Shift` + `Enter` | 交互式打开选中文件
+`Tab` | 显示文件信息
+`y` | 复制选中文件
+`x` | 剪切选中文件
+`p` | 粘贴
+`P` | 覆盖粘贴
+`Y`, `X` | 取消复制/剪切状态
+`d` | 移到回收站
+`D` | 永久删除
+`a` | 新建文件或目录
+`r` | 重命名
+`.` | 显示或隐藏隐藏文件
 <!--rehype:className=shortcuts left-align-->
 
-更多文件操作命令如下：
+### Shell 与链接
 
-| 快捷键                          | 操作说明                                     |
-| ------------------------------ | -------------------------------------------- |
-| <kbd>;</kbd>                   | 执行一个 Shell 命令                          |
-| <kbd>:</kbd>                   | 执行一个 Shell 命令（阻塞，直到命令完成）    |
-| <kbd>-</kbd>                   | 创建已复制文件的绝对路径符号链接             |
-| <kbd>\_</kbd>                  | 创建已复制文件的相对路径符号链接             |
-| <kbd>Ctrl</kbd> + <kbd>-</kbd> | 创建已复制文件的硬链接                       |
+键位 | 操作
+:- | :-
+`;` | 执行 shell 命令
+`:` | 执行阻塞式 shell 命令
+`-` | 创建绝对路径符号链接
+`_` | 创建相对路径符号链接
+`Ctrl` + `-` | 创建硬链接
 <!--rehype:className=shortcuts left-align-->
-
-要操作选中的文件或目录
 
 ### 复制路径
 
-| 快捷键                       | 操作说明                           |
-| ---------------------------- | ---------------------------------- |
-| <kbd>c</kbd> ⇒ <kbd>c</kbd> | 复制文件路径                       |
-| <kbd>c</kbd> ⇒ <kbd>d</kbd> | 复制目录路径                       |
-| <kbd>c</kbd> ⇒ <kbd>f</kbd> | 复制文件名                         |
-| <kbd>c</kbd> ⇒ <kbd>n</kbd> | 复制不带扩展名的文件名             |
+键位 | 操作
+:- | :-
+`c` ⇒ `c` | 复制文件路径
+`c` ⇒ `d` | 复制目录路径
+`c` ⇒ `f` | 复制文件名
+`c` ⇒ `n` | 复制不带扩展名的文件名
 <!--rehype:className=shortcuts left-align-->
-
-**复制路径** _说明：<kbd>c</kbd> ⇒ <kbd>d</kbd> 表示先按下 <kbd>c</kbd> 键，然后按下 <kbd>d</kbd> 键。_
 
 ### 搜索与过滤
 
-| 快捷键       | 操作说明             |
-| ------------ | -------------------- |
-| <kbd>f</kbd> | 过滤文件     |
-| <kbd>/</kbd> | 查找下一个文件       |
-| <kbd>?</kbd> | 查找上一个文件       |
-| <kbd>n</kbd> | 跳转到下一个匹配项   |
-| <kbd>N</kbd> | 跳转到上一个匹配项   |
+键位 | 操作
+:- | :-
+`f` | 过滤当前目录
+`/` | 查找下一个文件
+`?` | 查找上一个文件
+`n` | 跳到下一个匹配项
+`N` | 跳到上一个匹配项
+`s` | 使用 fd 按名称搜索文件
+`S` | 使用 ripgrep 按内容搜索文件
+`Ctrl` + `s` | 取消当前搜索
 <!--rehype:className=shortcuts left-align-->
-
-### 搜索文件
-
-| 快捷键                       | 操作说明                                                |
-| ---------------------------- | ------------------------------------------------------- |
-| <kbd>s</kbd>                 | 使用 [fd](https://github.com/sharkdp/fd) 按名称搜索文件 |
-| <kbd>S</kbd>                 | 使用 [ripgrep](https://github.com/BurntSushi/ripgrep) 按内容搜索文件 |
-| <kbd>Ctrl</kbd> + <kbd>s</kbd> | 取消当前进行中的搜索                                   |
-<!--rehype:className=shortcuts-->
 
 ### 排序
 <!--rehype:wrap-class=row-span-2-->
 
-| 快捷键                 | 操作说明                 |
-| ---------------------- | ------------------------ |
-| <kbd>,</kbd> ⇒ <kbd>m</kbd> | 按修改`时间`排序         |
-| <kbd>,</kbd> ⇒ <kbd>M</kbd> | 按修改`时间倒序`排序     |
-| <kbd>,</kbd> ⇒ <kbd>b</kbd> | 按`创建时间`排序         |
-| <kbd>,</kbd> ⇒ <kbd>B</kbd> | 按`创建时间`倒序排序     |
-| <kbd>,</kbd> ⇒ <kbd>e</kbd> | 按文件`扩展名`排序       |
-| <kbd>,</kbd> ⇒ <kbd>E</kbd> | 按文件`扩展名倒序`排序   |
-| <kbd>,</kbd> ⇒ <kbd>a</kbd> | 按`字母顺序`排序         |
-| <kbd>,</kbd> ⇒ <kbd>A</kbd> | 按`字母倒序`排序         |
-| <kbd>,</kbd> ⇒ <kbd>n</kbd> | 按`自然`排序             |
-| <kbd>,</kbd> ⇒ <kbd>N</kbd> | 按`自然倒序`排序         |
-| <kbd>,</kbd> ⇒ <kbd>s</kbd> | 按文件`大小`排序         |
-| <kbd>,</kbd> ⇒ <kbd>S</kbd> | 按文件`大小倒序`排序     |
-| <kbd>,</kbd> ⇒ <kbd>r</kbd> | `随机`排序               |
+键位 | 操作
+:- | :-
+`,` ⇒ `m` | 按修改时间排序
+`,` ⇒ `M` | 按修改时间倒序
+`,` ⇒ `b` | 按创建时间排序
+`,` ⇒ `B` | 按创建时间倒序
+`,` ⇒ `e` | 按扩展名排序
+`,` ⇒ `E` | 按扩展名倒序
+`,` ⇒ `a` | 按字母排序
+`,` ⇒ `A` | 按字母倒序
+`,` ⇒ `n` | 自然排序
+`,` ⇒ `N` | 自然倒序
+`,` ⇒ `s` | 按大小排序
+`,` ⇒ `S` | 按大小倒序
+`,` ⇒ `r` | 随机排序
 <!--rehype:className=shortcuts left-align-->
 
-对文件/目录进行排序说明： _<kbd>,</kbd> ⇒ <kbd>a</kbd> 表示先按下 <kbd>,</kbd> 键，再按下 <kbd>a</kbd> 键。_
+### 标签页
 
-### 多标签页
+键位 | 操作
+:- | :-
+`t` | 新建标签页
+`1` ... `9` | 切换到第 N 个标签页
+`[` | 上一个标签页
+`]` | 下一个标签页
+`{` | 与上一个标签页交换
+`}` | 与下一个标签页交换
+`Ctrl` + `c` | 关闭当前标签页
+<!--rehype:className=shortcuts left-align-->
 
-| 快捷键                                      | 操作说明                     |
-| ------------------------------------------- | ---------------------------- |
-| <kbd>t</kbd>                                | 以当前工作目录创建新标签页  |
-| <kbd>1</kbd>, <kbd>2</kbd>, ..., <kbd>9</kbd> | 切换到第 N 个标签页         |
-| <kbd>[</kbd>                                | 切换到上一个标签页          |
-| <kbd>]</kbd>                                | 切换到下一个标签页          |
-| <kbd>{</kbd>                                | 当前标签页与上一个互换位置  |
-| <kbd>}</kbd>                                | 当前标签页与下一个互换位置  |
-| <kbd>Ctrl</kbd> + <kbd>c</kbd>              | 关闭当前标签页              |
-<!--rehype:className=shortcuts-->
+配置
+----
 
-## 自定义配置
+### 配置文件
 
-### 自定义配置
+文件 | 说明
+:- | :-
+`yazi.toml` | 通用配置
+`keymap.toml` | 快捷键配置
+`theme.toml` | 配色配置
+`init.lua` | Lua 初始化脚本
+`package.toml` | 插件和主题锁定信息
+<!--rehype:className=show-header-->
 
-通过编辑配置文件来自定义 `Yazi`，配置文件通常位于 `$HOME/.config/yazi/xxx.toml`，可修改默认设置如快捷键、主题等。
+Unix-like 系统配置目录为 `~/.config/yazi/`，Windows 配置目录为 `%AppData%\yazi\config\`。也可以通过 `YAZI_CONFIG_HOME` 使用自定义配置目录。
 
-- `yazi.toml` - 常规配置
-- `keymap.toml` - 快捷键绑定
-- `theme.toml` - 主题配置
-
-### 配置文件示例：yazi.toml
-<!--rehype:wrap-class=row-span-2-->
-
-```toml
-[general]
-# 设置主界面主题为 dark 或 light
-theme = "dark"
-```
-
-启动时的默认路径
+### 显示隐藏文件
 
 ```toml
-default_path = "~"
+# yazi.toml
+[mgr]
+show_hidden = true
 ```
 
-是否启用自动保存配置
+Yazi 已内置默认配置，只需要在自己的配置文件里写入要覆盖的片段。
+
+### 布局比例
 
 ```toml
-auto_save_config = true
+# yazi.toml
+[mgr]
+ratio = [1, 4, 3]
 ```
 
-自定义快捷键绑定
+`ratio` 控制父目录、当前目录、预览面板的宽度比例。某一栏设为 `0` 可隐藏该栏，但至少需要保留一个非零面板。
+
+### keymap.toml 层
+<!--rehype:wrap-class=col-span-2-->
+
+层 | 说明
+:- | :-
+`mgr` | 文件列表
+`tasks` | 任务管理器
+`spot` | 文件信息查看
+`pick` | 选择组件，例如“打开方式”
+`input` | 输入组件，例如创建、重命名
+`confirm` | 确认对话框
+`cmp` | 补全组件
+`help` | 帮助菜单
+<!--rehype:className=show-header-->
+
+### 追加快捷键
 
 ```toml
-[keybindings]
-quit = "q"        # 退出
-copy = "y"        # 复制文件
-paste = "p"       # 粘贴文件
-delete = "d"      # 删除文件
+# keymap.toml
+[[mgr.prepend_keymap]]
+on = "<C-a>"
+run = "toggle_all --state=on"
+desc = "Select all files"
+
+[[mgr.append_keymap]]
+on = [ "g", "b" ]
+run = "cd ~/Books"
+desc = "Go to books"
 ```
 
-界面相关配置
+`prepend_keymap` 优先级高于默认快捷键，`append_keymap` 优先级低于默认快捷键。若要完全替换默认快捷键，可使用 `keymap`。
+
+插件与主题
+----
+
+### ya 命令
+
+```shell
+$ ya --help
+```
+
+`ya` 是 Yazi 的辅助命令，负责插件管理、主题管理和 DDS 消息发布订阅等功能。`ya` 与 `yazi` 版本必须一致。
+
+### 插件管理
+
+```shell
+$ ya pkg add owner/my-plugin
+$ ya pkg add yazi-rs/plugins:git
+$ ya pkg list
+$ ya pkg install
+$ ya pkg upgrade
+$ ya pkg delete yazi-rs/plugins:git
+```
+
+`ya pkg` 会把插件复制到配置目录，并更新 `package.toml` 来锁定版本。
+
+### 锁定插件版本
 
 ```toml
-[ui]
-preview_enabled = true     # 是否启用文件预览
-show_hidden_files = true   # 显示隐藏文件
-columns = 2                # 文件列表列数
+# package.toml
+[[plugin.deps]]
+use = "owner/my-plugin"
+rev = "=9a1129c"
+hash = "d81b64a39432fcd6224cd75d296e7510"
 ```
 
-搜索行为配置
+在 `rev` 前加 `=` 可固定插件版本，避免 `ya pkg upgrade` 自动升级。
+
+### Flavors
 
 ```toml
-[search]
-case_sensitive = false  # 搜索是否区分大小写
-search_timeout = 30     # 搜索超时时间（秒）
+# theme.toml
+[flavor]
+dark = "catppuccin-mocha"
+light = "catppuccin-mocha"
 ```
 
-排序规则配置
+Flavor 是可复用的预制主题，通常放在 `flavors/` 子目录中，并可由 `ya pkg` 管理。用户自己的 `theme.toml` 会覆盖 flavor 的同名配置。
 
-```toml
-[sorting]
-sort_by = "name" # 排序方式: name,size,date
-reverse_sort = false  # 是否反向排序
+### 安装 Flavor
+
+```shell
+$ ya pkg add yazi-rs/flavors:catppuccin-mocha
 ```
 
-插件加载配置
+如果只想使用某个 flavor，`theme.toml` 中通常只需要 `[flavor]` 配置；需要微调时再添加覆盖项。
 
-```toml
-[plugins]
-enabled_plugins = ["git", "archive"]
+排错
+----
+
+### 检查帮助
+
+```shell
+$ yazi --help
+$ ya --help
 ```
 
-### keymap.toml 配置示例
-<!--rehype:wrap-class=row-span-2-->
+先确认 `yazi` 和 `ya` 都在 `PATH` 中，并且两者版本一致。
 
-```toml
-# 全局快捷键配置
-[global]
-# 全局退出应用程序
-quit = "Ctrl+Q"
-# 打开文件或目录
-open = "Enter"
-# 返回上级目录
-back = "Backspace"
-# 搜索功能触发
-search = "/"
-# 复制路径
-copy_path = "Ctrl+C"
+### Windows 无法识别类型
 
-# 窗口控制快捷键
-[window]
-# 切换窗口
-switch_window = "Tab"
-# 新建窗口
-new_window = "Ctrl+N"
-# 关闭窗口
-close_window = "Ctrl+W"
-
-# 文件操作快捷键
-[file]
-# 删除文件
-delete_file = "D"
-# 重命名文件
-rename_file = "R"
-# 复制文件
-copy_file = "Y"
-# 粘贴文件
-paste_file = "P"
-# 移动文件
-move_file = "M"
-
-# 文件选择快捷键
-[selection]
-# 全选
-select_all = "Ctrl+A"
-# 取消所有选择
-deselect_all = "Ctrl+D"
-# 反选
-invert_selection = "Ctrl+I"
-# 选择当前文件/目录
-select_item = "Space"
-
-# 页面导航快捷键
-[navigation]
-# 向上移动光标
-move_up = "K"
-# 向下移动光标
-move_down = "J"
-# 向左切换标签
-move_left = "H"
-# 向右切换标签
-move_right = "L"
-
-# 自定义命令触发键
-[custom]
-# 触发自定义功能
-custom_action_1 = "Ctrl+1"
-custom_action_2 = "Ctrl+2"
-custom_action_3 = "Ctrl+3"
+```powershell
+$env:YAZI_FILE_ONE = "C:\Program Files\Git\usr\bin\file.exe"
 ```
 
-### theme.toml 配置示例
+如果预览或类型检测异常，优先确认 `YAZI_FILE_ONE` 是否指向 Git for Windows 附带的 `file.exe`。
 
-```toml
-[general]
-# 设置主界面配色方案
-background_color = "#1e1e2e"  # 背景颜色
-foreground_color = "#cdd6f4"  # 文本颜色
-cursor_color = "#89dceb"      # 光标颜色
-selection_color = "#585b70"   # 选中项背景颜色
-highlight_color = "#fab387"   # 高亮颜色
+### 配置目录调试
 
-# 字体设置
-font_family = "FiraCode"      # 字体名称
-font_size = 14                # 字体大小
-
-[ui]
-# 界面边框与间距
-border_color = "#45475a"      # 边框颜色
-padding = 4                   # 界面内容的内边距
-
-[file_browser]
-# 文件浏览器颜色配置
-directory_color = "#89b4fa"   # 目录名称颜色
-file_color = "#cdd6f4"        # 普通文件颜色
-symlink_color = "#f5c2e7"     # 符号链接颜色
-hidden_file_color = "#6c7086" # 隐藏文件颜色
-
-[status_bar]
-# 状态栏颜色
-background_color = "#313244"  # 状态栏背景
-foreground_color = "#a6adc8"  # 状态栏文字
-error_color = "#f38ba8"       # 状态栏错误信息
-
-[search]
-# 搜索结果配色
-match_color = "#a6e3a1"       # 搜索结果的匹配高亮
-current_match_color = "#fab387"  # 当前匹配项的高亮
-
-[progress_bar]
-# 进度条的配色
-filled_color = "#89dceb"      # 已填充部分
-empty_color = "#313244"       # 未填充部分
+```shell
+$ YAZI_CONFIG_HOME=~/.config/yazi-alt yazi
 ```
+
+用独立配置目录启动可以排查现有配置、插件或主题是否导致问题。
+
+### 主题校验
+
+```shell
+$ taplo check --schema https://yazi-rs.github.io/schemas/theme.json theme.toml
+```
+
+Flavor 或主题不生效时，检查字段是否与当前 Yazi 版本兼容。
 
 另见
 ----
 
-- [Yazi 官方文档](https://yazi-rs.github.io/) _(yazi-rs.github.io)_
-- [Yazi Github](https://github.com/sxyazi/yazi) _(github.com)_
+- [Yazi 官方文档](https://yazi-rs.github.io/docs/)
+- [Yazi Installation](https://yazi-rs.github.io/docs/installation/)
+- [Yazi Quick Start](https://yazi-rs.github.io/docs/quick-start/)
+- [Yazi Configuration](https://yazi-rs.github.io/docs/configuration/overview/)
+- [Yazi CLI](https://yazi-rs.github.io/docs/cli/)
+- [Yazi Flavors](https://yazi-rs.github.io/docs/flavors/overview/)


### PR DESCRIPTION
## Summary

- 完善 `docs/yazi.md`，补充安装、启动、快捷键、配置、插件、主题和排错内容。
- 修正过时或不准确的安装与配置示例，改为当前官方文档中的配置结构。
- 更新 `README.md` 中 Yazi 的完成状态。

## References

- Yazi Installation
- Yazi Quick Start
- Yazi Configuration
- Yazi CLI
- Yazi Flavors

## Validation

- `npx --yes markdownlint-cli docs/yazi.md`
- `git diff --check`
- `npm.cmd run build`