### PR TITLE
完善 htmx 备忘清单

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Quick Reference
 [TypeScript](./docs/typescript.md)<!--rehype:style=background:rgb(49 120 198);-->
 [Vue 2](./docs/vue2.md)<!--rehype:style=background:rgb(64 184 131);&class=tag&data-lang=Vue-->
 [Vue 3](./docs/vue.md)<!--rehype:style=background:rgb(64 184 131);&class=tag&class=contributing tag&data-lang=Vue-->
-[</> htmx](./docs/htmx.md)<!--rehype:style=background:rgb(52 101 164);&class=contributing-->
+[</> htmx](./docs/htmx.md)<!--rehype:style=background:rgb(52 101 164);-->
 [Pinia](./docs/pinia.md)<!--rehype:style=background:rgb(44 136 50);&class=tag&data-lang=Vue-->
 <!--rehype:class=home-card-->
 

--- a/docs/htmx.md
+++ b/docs/htmx.md
@@ -1,108 +1,219 @@
 \</> htmx 备忘清单
 ===
 
-[![NPM version](https://img.shields.io/npm/v/htmx.org.svg?style=flat)](https://npmjs.org/package/htmx.org)
-[![Downloads](https://img.shields.io/npm/dm/htmx.org.svg?style=flat)](https://www.npmjs.com/package/htmx.org)
-[![Repo Dependents](https://badgen.net/github/dependents-repo/bigskysoftware/htmx)](https://github.com/bigskysoftware/htmx/network/dependents)
-[![Github repo](https://badgen.net/badge/icon/Github?icon=github&label)](https://github.com/bigskysoftware/htmx)
-
-适合初学者的综合 [htmx](https://htmx.org/) 备忘清单
+[htmx](https://htmx.org/) 是一个面向浏览器、无运行时依赖的 JavaScript 库。它通过 `hx-*` HTML 属性让页面直接发起 AJAX 请求、局部替换 HTML、处理 CSS 过渡，并通过扩展支持 WebSocket、SSE 等能力。
 <!--rehype:style=padding-top: 12px;-->
 
 入门
 ---
 
-### 快速开始
+### 安装
+<!--rehype:wrap-class=row-span-2-->
 
-[htmx](https://htmx.org/) 是 [intercooler.js](http://intercoolerjs.org/) 的继承者
+:-- | --
+:-- | --
+CDN | `<script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.10/dist/htmx.min.js"></script>`
+下载文件 | 下载 `htmx.min.js` 后用普通 `<script>` 引入
+npm | `npm install htmx.org@2.0.10`
+Webpack / bundler | `import "htmx.org";`
+全局变量 | `window.htmx = require("htmx.org");`
+扩展 | 先加载 htmx，再加载扩展并使用 `hx-ext`
+<!--rehype:className=left-align code-nowrap-->
+
+htmx 2.x 是当前主线；1.x 仍支持 IE11。生产环境使用 CDN 时建议固定版本，并按官方下载页更新 `integrity` 值。
+
+### 第一个请求
 
 ```html
-<script
-  src="https://unpkg.com/htmx.org@2.0.6"
-  integrity="sha384-Akqfrbj/HpNVo8k11SXBb6TlBWmXXlYQrCSqEWmyKJe+hDm3Z/B2WVG4smwBkRVm"
-  crossorigin="anonymous"
->
-</script>
-<!-- 有一个按钮POST，通过AJAX点击 -->
-<button
-  hx-post="/clicked"
-  hx-swap="outerHTML"
->
+<button hx-post="/clicked" hx-swap="outerHTML">
   点击我
 </button>
 ```
-<!--rehype:className=wrap-text-->
 
-`hx-post` 和 `hx-swap` 属性告诉 `htmx`：
+当按钮被点击时，htmx 会向 `/clicked` 发出 `POST` 请求，并用响应 HTML 替换整个按钮。
 
-> 当用户单击此按钮时，向 `/clicked` 发出 `AJAX` 请求，并用响应替换整个按钮
+### AJAX 方法
 
-```bash
-$ npm install htmx.org
+:-- | --
+:-- | --
+`hx-get="/url"` | 发起 `GET` 请求
+`hx-post="/url"` | 发起 `POST` 请求
+`hx-put="/url"` | 发起 `PUT` 请求
+`hx-patch="/url"` | 发起 `PATCH` 请求
+`hx-delete="/url"` | 发起 `DELETE` 请求
+<!--rehype:className=left-align code-nowrap-->
+
+默认触发事件按元素类型决定：`input`、`textarea`、`select` 为 `change`，`form` 为 `submit`，其他元素为 `click`。
+
+请求与交换
+---
+
+### hx-trigger
+<!--rehype:wrap-class=row-span-2-->
+
+:-- | --
+:-- | --
+`hx-trigger="click"` | 点击时触发
+`hx-trigger="mouseenter"` | 鼠标进入时触发
+`hx-trigger="load"` | 元素加载后触发
+`hx-trigger="every 2s"` | 每 2 秒轮询
+`hx-trigger="keyup changed delay:500ms"` | 值变化且停止输入 500ms 后触发
+`hx-trigger="click once"` | 只触发一次
+`hx-trigger="click[ctrlKey]"` | 满足事件过滤表达式才触发
+`hx-trigger="load, click delay:1s"` | 多个触发器组合
+<!--rehype:className=left-align code-nowrap-->
+
+常用修饰符：
+
+- `once`：只触发一次
+- `changed`：值变化时才触发
+- `delay:<time>`：延迟触发，期间再次触发会重置计时
+- `throttle:<time>`：节流触发
+- `from:<selector>`：监听其他元素上的事件
+- `target:<selector>`：只处理来自匹配目标的事件
+<!--rehype:className=cols-2 style-none-->
+
+### hx-target
+
+:-- | --
+:-- | --
+`hx-target="#result"` | 将响应换入指定元素
+`hx-target="this"` | 目标为当前元素
+`hx-target="closest tr"` | 目标为最近的表格行
+`hx-target="next .panel"` | 目标为后续匹配元素
+`hx-target="previous .item"` | 目标为前一个匹配元素
+`hx-target="find .body"` | 目标为当前元素内的匹配子元素
+<!--rehype:className=left-align code-nowrap-->
+
+#### 示例
+
+```html
+<input
+  name="q"
+  hx-get="/search"
+  hx-trigger="keyup changed delay:500ms"
+  hx-target="#search-results"
+  placeholder="搜索">
+<div id="search-results"></div>
 ```
 
-安装 `htmx` 将导入添加到您的 `index.js`
+### hx-swap
+<!--rehype:wrap-class=row-span-2-->
 
-```js
-import 'htmx.org';
+:-- | --
+:-- | --
+`innerHTML` | 默认，替换目标元素内部 HTML
+`outerHTML` | 替换整个目标元素
+`beforebegin` | 插入到目标元素之前
+`afterbegin` | 插入到目标元素内部开头
+`beforeend` | 插入到目标元素内部结尾
+`afterend` | 插入到目标元素之后
+`delete` | 删除目标元素
+`none` | 不换入主体内容，仍处理带外交换
+<!--rehype:className=left-align code-nowrap-->
+
+常用修饰符：
+
+:-- | --
+:-- | --
+`swap:1s` | 收到响应后延迟 1 秒再交换
+`settle:500ms` | 交换后等待 500ms 再 settle
+`transition:true` | 使用 View Transitions API
+`ignoreTitle:true` | 忽略响应中的 `<title>`
+`scroll:bottom` | 交换后滚动到底部
+`show:top` | 交换后显示目标顶部
+<!--rehype:className=left-align code-nowrap-->
+
+### 选择与带外交换
+
+:-- | --
+:-- | --
+`hx-select="#content"` | 从响应中选择局部内容换入
+`hx-select-oob="#alert"` | 从响应中挑选带外内容
+`hx-swap-oob="true"` | 响应片段按 `id` 直接更新页面其他位置
+`hx-preserve` | 在交换中保留元素
+<!--rehype:className=left-align code-nowrap-->
+
+表格中的 `tr`、`td` 等片段用于带外交换时，建议用 `<template>` 包裹，避免浏览器解析 HTML 时丢失结构。
+
+参数与表单
+---
+
+### 参数提交
+
+:-- | --
+:-- | --
+普通输入元素 | 如果元素有 `name` 和值，会随请求提交
+`form` | 提交表单内所有输入值
+非 `GET` 请求 | 会包含关联表单的输入值
+`hx-include="#extra"` | 额外包含其他元素的值
+`hx-params="not csrf"` | 过滤请求参数
+`hx-vals='{"page": 1}'` | 添加 JSON 格式的额外值
+`htmx:configRequest` | 发请求前用事件修改参数或请求头
+<!--rehype:className=left-align code-nowrap-->
+
+### 文件上传
+
+```html
+<form
+  hx-post="/upload"
+  hx-encoding="multipart/form-data"
+  hx-target="#result">
+  <input type="file" name="file">
+  <button>上传</button>
+</form>
+<progress id="progress" value="0" max="100"></progress>
+<div id="result"></div>
 ```
 
-### 点击编辑提交
+上传时可监听 `htmx:xhr:progress` 显示进度。
+
+### 确认与提示
+
+:-- | --
+:-- | --
+`hx-confirm="确定删除？"` | 请求前显示确认框
+`hx-prompt="请输入名称"` | 请求前显示提示框
+`htmx:confirm` | 自定义异步确认流程
+`HX-Prompt` | 请求头中包含用户对 prompt 的响应
+<!--rehype:className=left-align code-nowrap-->
+
+常见模式
+---
+
+### 点击编辑
 <!--rehype:wrap-class=col-span-2-->
-
-有一个按钮，可以从 `/contacts/1/edit` 获取联系人的编辑 UI
 
 ```html
 <div hx-target="this" hx-swap="outerHTML">
   <div><label>名字</label>: Joe</div>
-  <div><label>姓</label>: Blow</div>
-  <div><label>邮箱</label>: joe@blow.com</div>
-  <button hx-get="/contact/1/edit" class="btn btn-primary">
-    点击编辑
-  </button>
+  <div><label>邮箱</label>: joe@example.com</div>
+  <button hx-get="/contacts/1/edit">编辑</button>
 </div>
 ```
 
-这将返回一个可用于编辑联系人的表单
+服务器返回表单：
 
 ```html
-<form hx-put="/contact/1" hx-target="this" hx-swap="outerHTML">
-  <div>
-    <label>名字</label>
-    <input type="text" name="firstName" value="Joe">
-  </div>
-  <div class="form-group">
-    <label>姓</label>
-    <input type="text" name="lastName" value="Blow">
-  </div>
-  <div class="form-group">
-    <label>邮箱</label>
-    <input type="email" name="email" value="joe@blow.com">
-  </div>
-  <button class="btn">提交</button>
-  <button class="btn" hx-get="/contact/1">取消</button>
-</form> 
+<form hx-put="/contacts/1" hx-target="this" hx-swap="outerHTML">
+  <input name="firstName" value="Joe">
+  <input name="email" value="joe@example.com">
+  <button>保存</button>
+  <button hx-get="/contacts/1">取消</button>
+</form>
 ```
-
-表单按照通常的 `REST-ful` 模式将 `PUT` 发回 `/contacts/1`
 
 ### 删除行
-<!--rehype:wrap-class=col-span-2 row-span-2-->
 
 ```html
-<table class="table delete-row-example">
-  <thead>
-    <tr>
-      <th>Name</th> <th>Email</th> <th>Status</th> <th></th>
-    </tr>
-  </thead>
-  <tbody hx-confirm="Are you sure?" hx-target="closest tr" hx-swap="outerHTML swap:1s">
-    ...
-  </tbody>
-</table>
+<tbody hx-confirm="确定删除？" hx-target="closest tr" hx-swap="outerHTML swap:1s">
+  <tr>
+    <td>Joe</td>
+    <td>joe@example.com</td>
+    <td><button hx-delete="/contacts/1">删除</button></td>
+  </tr>
+</tbody>
 ```
-
-表体有一个 `hx-confirm` 属性来确认删除动作。 它还将所有按钮的目标设置为最近的 `tr`，即最近的表格行（`hx-target` 继承自 DOM 中的父级）`hx-swap` 中的交换规范表示将整个目标换出并收到响应后等待 1 秒。最后一点是为了让我们可以使用以下 CSS：
 
 ```css
 tr.htmx-swapping td {
@@ -111,223 +222,201 @@ tr.htmx-swapping td {
 }
 ```
 
-在交换/删除之前淡出该行。每行都有一个带有 `hx-delete` 属性的按钮，该属性包含发出 `DELETE` 请求以从服务器中删除该行的 `url`。此请求以空内容响应，表明该行应替换为空内容
-
-```html
-<tr>
-  <td>Angie MacDowell</td>
-  <td>angie@macdowell.org</td>
-  <td>Active</td>
-  <td>
-    <button class="btn btn-danger" hx-delete="/contact/1">
-      Delete
-    </button>
-  </td>
-</tr>
-```
-
-### 延迟加载
+### 延迟加载与轮询
 
 ```html
 <div hx-get="/graph" hx-trigger="load">
-  <img
-    alt="正在加载中..."
-    class="htmx-indicator"
-    width="150"
-    src="/img/bars.svg"/>
+  <img class="htmx-indicator" src="/spinner.svg" alt="加载中">
 </div>
+
+<div hx-get="/news" hx-trigger="every 2s"></div>
 ```
 
-当我们加载图表时显示进度指示器。 然后通过稳定的 CSS(`htmx-settling`) 过渡加载图形并逐渐淡入视图
+服务器可返回 HTTP `286` 来停止轮询。
 
-```css
-.htmx-settling img {
-  opacity: 0;
-}
-img {
-  transition: opacity 300ms ease-in;
-}
+### 请求指示器
+
+```html
+<button hx-get="/save" hx-indicator="#indicator">
+  保存
+</button>
+<img id="indicator" class="htmx-indicator" src="/spinner.svg" alt="加载中">
 ```
 
-### hx-swap
-
-:-- | --
-:-- | --
-`innerHTML` | 默认，替换目标元素的内部 `html`
-`outerHTML` | 用响应替换整个目标元素
-`beforebegin` | 在目标元素之前插入响应
-`afterbegin` | 目标元素的第一个子元素之前插入响应
-`beforeend` | 目标元素的最后一个子元素之后插入响应
-`afterend` | 在目标元素之后插入响应
-`delete` | 无论响应如何，都删除目标元素
-`none` | 不附加来自响应的内容 <br />_(带外项目仍将被处理)_
-<!--rehype:className=left-align-->
+请求期间 htmx 会添加 `htmx-request` 类，默认会让 `.htmx-indicator` 显示出来。
 
 API 参考
 ---
 <!--rehype:body-class=cols-2-->
 
-### 核心属性参考
+### 核心属性
 
 属性 | 说明
 :- | --
-`hx-boost` | 添加或删除链接和表单的[渐进增强](https://en.wikipedia.org/wiki/Progressive_enhancement)
-`hx-get` | 向指定的 URL 发出 `GET`
-`hx-post` | 向指定的 URL 发出 `POST`
-`hx-push-url` | 将 URL 推入浏览器地址栏，创建一个新的历史条目
-`hx-select` | 从响应中选择要换入的内容
-`hx-select-oob` | 从带外(目标以外的某个地方)的响应中选择要换入的内容
-`hx-swap` | 控制内容的交换方式(`outerHTML`、`beforeEnd`、`afterend`，...)
-`hx-swap-oob` | 将响应中的内容标记为带外(应该在目标以外的地方交换)
-`hx-target` | 指定要交换的目标元素
+`hx-boost` | 增强链接和表单，使用 AJAX 替代整页跳转
+`hx-get` | 发起 `GET` 请求
+`hx-post` | 发起 `POST` 请求
+`hx-put` | 发起 `PUT` 请求
+`hx-patch` | 发起 `PATCH` 请求
+`hx-delete` | 发起 `DELETE` 请求
 `hx-trigger` | 指定触发请求的事件
-`hx-vals` | 向参数添加值以随请求一起提交(JSON 格式)
+`hx-target` | 指定响应内容换入的目标
+`hx-swap` | 指定内容交换方式
+`hx-select` | 从响应中选择要换入的内容
+`hx-push-url` | 将 URL 推入浏览器历史
+`hx-replace-url` | 替换当前浏览器 URL
+`hx-swap-oob` | 处理响应中的带外交换
 <!--rehype:className=left-align-->
 
-使用 htmx 时最常用的属性
-
-### 附加属性参考
+### 附加属性
 <!--rehype:wrap-class=row-span-2-->
 
 属性 | 说明
 :- | --
-`hx-confirm` | 在发出请求之前显示一个 `confim()` 对话框
-`hx-delete` | 向指定的 URL 发出 `DELETE`
-`hx-disable` | 禁用给定节点和任何子节点的 htmx 处理
-`hx-disinherit` | 控制和禁用子节点的自动属性继承
-`hx-encoding` | 更改请求编码类型
-`hx-ext` | 用于此元素的扩展
-`hx-headers` | 添加到将与请求一起提交的标头
-`hx-history-elt` | 在历史导航期间要快照和恢复的元素
-`hx-include` | 在请求中包含额外数据
-`hx-indicator` | 在请求期间放置 `htmx-request` 类的元素
-`hx-params` | 过滤将与请求一起提交的参数
-`hx-patch` | 向指定的 URL 发出 PATCH
-`hx-preserve` | 指定在请求之间保持不变的元素
-`hx-prompt` | 在提交请求之前显示一个 `prompt()`
-`hx-put` | 向指定的 URL 发出 PUT
-`hx-replace-url` | 替换浏览器地址栏中的 URL
-`hx-request` | 配置请求的各个方面
-`hx-sync` | 控制不同元素发出的请求如何同步
-`hx-validate` | 强制元素在请求之前验证自己
-`hx-disabled-elt` | 禁用触发元素和指定的元素，在发出请求期间
+`hx-confirm` | 请求前显示确认对话框
+`hx-disabled-elt` | 请求期间禁用触发元素或指定元素
+`hx-disable` | 禁用当前节点及子节点的 htmx 处理
+`hx-disinherit` | 禁用属性继承
+`hx-encoding` | 设置请求编码，如 `multipart/form-data`
+`hx-ext` | 启用扩展
+`hx-headers` | 添加请求头
+`hx-history-elt` | 指定历史快照元素
+`hx-include` | 包含额外输入值
+`hx-indicator` | 指定请求期间显示状态的元素
+`hx-params` | 过滤请求参数
+`hx-preserve` | 交换时保留元素
+`hx-prompt` | 请求前显示提示框
+`hx-request` | 配置请求行为
+`hx-select-oob` | 从响应中选择带外交换内容
+`hx-sync` | 控制多个请求之间的同步
+`hx-validate` | 请求前触发表单验证
+`hx-vals` | 添加 JSON 格式参数
 <!--rehype:className=left-align-->
 
-列出了 htmx 中可用的所有其他属性
-
-### CSS 类参考
+### CSS 类
 
 Class | 说明
 :- | --
-`htmx-added` | 在交换之前应用于新的内容，在它被解决之后移除
-`htmx-indicator` | 一个动态生成的类，当存在 `htmx-request` 类时将切换可见<br /> _(不透明度：`1`)_
-`htmx-request` | 在请求进行时应用于元素或使用 `hx-indicator` 指定的元素
-`htmx-settling` | 内容交换后应用于目标，内容确定后删除。<br /> _可以通过 `hx-swap` 修改持续时间_
-`htmx-swapping` | 在交换任何内容之前应用于目标，在交换之后移除。<br /> _可以通过 `hx-swap` 修改持续时间_
+`htmx-added` | 新内容换入前添加，settle 后移除
+`htmx-indicator` | 请求指示器元素，默认隐藏
+`htmx-request` | 请求期间添加到触发元素或指示器元素
+`htmx-settling` | 内容交换后、settle 前添加
+`htmx-swapping` | swap 前添加，可用于离场动画
 
-### 事件参考
-<!--rehype:wrap-class=row-span-3-->
+### 常用事件
+<!--rehype:wrap-class=row-span-2-->
 
 事件 | 说明
 :- | --
-`htmx:abort` | 将此事件发送到元素以中止请求
-`htmx:afterOnLoad` | AJAX 请求完成处理成功响应后触发
-`htmx:afterProcessNode` | 在 htmx 初始化节点后触发
-`htmx:afterRequest` | AJAX 请求完成后触发
-`htmx:afterSettle` | DOM 稳定后触发
-`htmx:afterSwap` | 换入新内容后触发
-`htmx:beforeOnLoad` | 在任何响应处理发生之前触发
-`htmx:beforeProcessNode` | 在 htmx 初始化节点之前触发
-`htmx:beforeRequest` | 在发出 AJAX 请求之前触发
-`htmx:beforeSwap` | 在交换完成之前触发，允许您配置交换
-`htmx:beforeSend` | 在发送 ajax 请求之前触发
-`htmx:configRequest` | 在请求之前触发，允许您自定义参数、标头
-`htmx:confirm` | 在元素上发生触发器后触发<br /> _允许您取消(或延迟)发出 AJAX 请求_
-`htmx:historyCacheError` | 在缓存写入期间因错误而触发
-`htmx:historyCacheMiss` | 在历史子系统中的缓存未命中时触发
-`htmx:historyCacheMissError` | 远程检索不成功时触发
-`htmx:historyCacheMissLoad` | 在成功的远程检索时触发
-`htmx:historyRestore` | 当 htmx 处理历史恢复操作时触发
-`htmx:beforeHistorySave` | 在内容保存到历史缓存之前触发
-`htmx:load` | 当新内容添加到 DOM 时触发
-`htmx:noSSESourceError` | 当元素在其触发器中引用 SSE 事件<br/> _但未定义父 SSE 源时触发_
-`htmx:onLoadError` | htmx中onLoad处理异常时触发
-`htmx:oobAfterSwap` | 在交换了一个带元素之后触发
-`htmx:oobBeforeSwap` | 在带外元素交换完成之前触发，允许您配置交换
-`htmx:oobErrorNoTarget` | 当带外元素在当前 DOM 中没有匹配的 ID 时触发
-`htmx:prompt` | 显示提示后触发
-`htmx:pushedIntoHistory` | 在 url 被推送到历史记录后触发
-`htmx:responseError` | 当发生 HTTP 响应错误<br/> _(非 200 或 300 响应代码)时触发_
-`htmx:sendError` | 当网络错误阻止 HTTP 请求发生时触发
-`htmx:sseError` | 当 SSE 源发生错误时触发
-`htmx:swapError` | 在交换阶段发生错误时触发
-`htmx:targetError` | 指定无效目标时触发
-`htmx:timeout` | 发生请求超时时触发
-`htmx:validation:validate` | 在验证元素之前触发
-`htmx:validation:failed` | 当元素验证失败时触发
-`htmx:validation:halted` | 当请求由于验证错误而停止时触发
-`htmx:xhr:abort` | 当 `ajax` 请求中止时触发
-`htmx:xhr:loadend` | `ajax` 请求结束时触发
-`htmx:xhr:loadstart` | `ajax` 请求开始时触发
-`htmx:xhr:progress` | 在支持进度事件的 `ajax` 请求期间定期触发
+`htmx:beforeRequest` | 发出请求前触发
+`htmx:configRequest` | 请求前配置参数和请求头
+`htmx:beforeSend` | XHR 发送前触发
+`htmx:afterRequest` | 请求完成后触发
+`htmx:beforeSwap` | 交换前触发，可改变目标或 swap 方式
+`htmx:afterSwap` | 内容换入后触发
+`htmx:afterSettle` | DOM settle 后触发
+`htmx:load` | 新内容加入 DOM 后触发
+`htmx:confirm` | 请求确认阶段触发
+`htmx:responseError` | HTTP 错误响应时触发
+`htmx:sendError` | 网络发送失败时触发
+`htmx:timeout` | 请求超时时触发
+`htmx:xhr:progress` | XHR 进度事件，常用于上传
 
-### JavaScript API 参考
+### JavaScript API
+<!--rehype:wrap-class=row-span-2-->
 
 方法 | 说明
 :- | --
-`htmx.addClass()` | 向给定元素添加一个类
-`htmx.ajax()` | 发出一个 htmx 风格的 ajax 请求
-`htmx.closest()` | 找到与选择器匹配的给定元素的最近父级
-`htmx.config` | 保存当前 htmx 配置对象的属性
-`htmx.createEventSource` | 包含为 htmx 创建 SSE EventSource 对象的函数的属性
-`htmx.createWebSocket` | 包含为 htmx 创建 WebSocket 对象的函数的属性
-`htmx.defineExtension()` | 定义一个 htmx 扩展
-`htmx.find()` | 查找与选择器匹配的单个元素
-`htmx.findAll()` \| `htmx.findAll(elt, selector)` | 查找与给定选择器匹配的所有元素
-`htmx.logAll()` | 安装将记录所有 htmx 事件的记录器
-`htmx.logger` | 设置为当前记录器的属性（默认为空）
-`htmx.off()` | 从给定元素中删除事件侦听器
-`htmx.on()` | 在给定元素上创建事件侦听器，并返回它
-`htmx.onLoad()` | 为 htmx:load 事件添加回调处理程序
-`htmx.parseInterval()` | 将间隔声明解析为毫秒值
-`htmx.process()` | 处理给定元素及其子元素，连接任何 htmx 行为
-`htmx.remove()` | 删除给定的元素
-`htmx.removeClass()` | 从给定元素中删除一个类
-`htmx.removeExtension()` | 删除一个 htmx 扩展
-`htmx.takeClass()` | 从给定元素的其他元素中获取一个类
-`htmx.toggleClass()` | 从给定元素切换一个类
-`htmx.trigger()` | 在元素上触发事件
-`htmx.values()` | 返回与给定元素关联的输入值
+`htmx.ajax()` | 发起 htmx 风格 AJAX 请求
+`htmx.trigger()` | 触发元素事件
+`htmx.on()` | 添加事件监听器
+`htmx.off()` | 移除事件监听器
+`htmx.onLoad()` | 监听 htmx 加载的新内容
+`htmx.process()` | 处理动态加入的 DOM
+`htmx.find()` | 查找单个元素
+`htmx.findAll()` | 查找多个元素
+`htmx.closest()` | 查找最近祖先元素
+`htmx.addClass()` | 添加类
+`htmx.removeClass()` | 移除类
+`htmx.toggleClass()` | 切换类
+`htmx.takeClass()` | 从同级元素中取得唯一类
+`htmx.logAll()` | 打开所有 htmx 事件日志
+`htmx.logger` | 自定义日志函数
 
-### 请求标头参考
+### 请求头
 
 标头 | 说明
 :- | --
-`HX-Boosted` | 表示请求是通过使用 `hx-boost` 的元素发出的
-`HX-Current-URL` | 浏览器的当前 `URL`
-`HX-History-Restore-Request` | 如果请求是在本地历史缓存未命中后进行历史恢复，则为 `true`
-`HX-Prompt` | 用户对 `hx` 提示的响应
-`HX-Request` | 总是 `true`
-`HX-Target` | 目标元素的 id(如果存在)
-`HX-Trigger-Name` | 触发元素的名称(如果存在)
-`HX-Trigger` | 触发元素的 id(如果存在)
+`HX-Boosted` | 请求来自 `hx-boost`
+`HX-Current-URL` | 当前浏览器 URL
+`HX-History-Restore-Request` | 历史恢复请求
+`HX-Prompt` | 用户对 `hx-prompt` 的响应
+`HX-Request` | htmx 请求总是为 `true`
+`HX-Target` | 目标元素 id
+`HX-Trigger-Name` | 触发元素 name
+`HX-Trigger` | 触发元素 id
 
-### 响应标头参考
+### 响应头
+<!--rehype:wrap-class=row-span-2-->
 
 标头 | 说明
 :- | --
-[`HX-Location`](https://htmx.org/headers/hx-location) | 允许您执行不执行整页重新加载的客户端重定向
-[`HX-Push-Url`](https://htmx.org/headers/hx-push-url) | 将一个新的 `url` 推入历史堆栈
-`HX-Redirect` | 可用于将客户端重定向到新位置
-`HX-Refresh` | 如果设置为 `true`，客户端将完全刷新页面
-[`HX-Replace-Url`](https://htmx.org/headers/hx-replace-url) | 替换地址栏中的当前 `URL`
-`HX-Reswap` | 允许您指定如何交换响应<br /> _有关可能的值，请参阅 [`hx-swap`](https://htmx.org/attributes/hx-swap)_
-`HX-Retarget` | 将内容更新的目标更新为页面上不同元素的 CSS 选择器
-[`HX-Trigger`](https://htmx.org/headers/hx-trigger) | 响应接收后立即触发事件<br /> _请[参阅文档](https://htmx.org/headers/hx-trigger)以获取更多信息_
-[`HX-Trigger-After-Settle`](https://htmx.org/headers/hx-trigger) | 在 settle 阶段之后触发事件<br /> _请[参阅文档](https://htmx.org/headers/hx-trigger)以获取更多信息_
-[`HX-Trigger-After-Swap`](https://htmx.org/headers/hx-trigger) | 在 swap 阶段之后触发事件<br /> _请[参阅文档](https://htmx.org/headers/hx-trigger)以获取更多信息_
+`HX-Location` | 客户端跳转但不整页刷新
+`HX-Push-Url` | 推入新的浏览器历史 URL
+`HX-Redirect` | 浏览器重定向到新地址
+`HX-Refresh` | 值为 `true` 时刷新整页
+`HX-Replace-Url` | 替换当前浏览器 URL
+`HX-Reswap` | 覆盖客户端 `hx-swap`
+`HX-Retarget` | 覆盖客户端目标元素
+`HX-Reselect` | 覆盖客户端 `hx-select`
+`HX-Trigger` | 响应收到后触发事件
+`HX-Trigger-After-Swap` | swap 后触发事件
+`HX-Trigger-After-Settle` | settle 后触发事件
+
+扩展与调试
+---
+
+### 扩展
+
+:-- | --
+:-- | --
+`hx-ext="response-targets"` | 按 HTTP 状态码选择目标
+`hx-ext="sse"` | Server-Sent Events 支持
+`hx-ext="ws"` | WebSocket 支持
+`hx-ext="preload"` | 预加载内容
+`hx-ext="head-support"` | 合并响应中的 head 信息
+`hx-ext="htmx-1-compat"` | 恢复部分 htmx 1.x 行为
+<!--rehype:className=left-align code-nowrap-->
+
+扩展必须在核心 htmx 之后加载，社区扩展可能有不同安装方式，使用前应查看对应扩展仓库。
+
+### 调试
+
+:-- | --
+:-- | --
+`htmx.logAll()` | 在控制台记录所有 htmx 事件
+`htmx.logger = fn` | 自定义日志输出
+`HX-Request: true` | 服务端识别 htmx 请求
+Network 面板 | 查看 `HX-*` 请求头和响应头
+`htmx:beforeSwap` | 调试目标、响应和交换行为
+`htmx:responseError` | 处理非 2xx/3xx 响应
+<!--rehype:className=left-align-->
+
+### 全局配置
+
+```html
+<meta name="htmx-config" content='{"defaultSwapStyle":"outerHTML"}'>
+```
+
+也可以直接修改 `htmx.config`。常见配置包括默认 swap 样式、请求超时、是否允许属性继承、是否携带跨站凭据等。
 
 参考资料
 ---
 
-- [HTMX 官方文档](https://htmx.org/docs/) _(htmx.org)_
+- [htmx Documentation](https://htmx.org/docs/)
+- [htmx Reference](https://htmx.org/reference/)
+- [hx-trigger](https://htmx.org/attributes/hx-trigger/)
+- [hx-swap](https://htmx.org/attributes/hx-swap/)
+- [hx-target](https://htmx.org/attributes/hx-target/)
+- [htmx Events](https://htmx.org/events/)
+- [HX-Trigger Response Headers](https://htmx.org/headers/hx-trigger/)


### PR DESCRIPTION
## Summary

- 重整 htmx 备忘清单结构，补充安装、AJAX 方法、触发器、目标选择、交换方式、参数表单和常见模式
- 增加 htmx 2.x、扩展、事件、请求/响应头、JavaScript API、调试和全局配置说明
- 移除首页 htmx 条目的待完善标记

## References

- htmx Documentation
- htmx Reference
- hx-trigger
- hx-swap
- hx-target
- htmx Events
- HX-Trigger Response Headers

## Validation

- `npx --yes markdownlint-cli docs/htmx.md`
- `git diff --check`
- `npm.cmd run build`